### PR TITLE
Incorporate esmcol-validator into intake-esm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ shared: &shared
         name: Install dependencies in (base environment)
         command: |
           conda env update -n base -f ${ENV_FILE}
+          conda activate base
+          python -m pip install -e .
 
     - run:
         name: List packages in the current environment (base)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ shared: &shared
         name: Install dependencies in (base environment)
         command: |
           conda env update -n base -f ${ENV_FILE}
-          conda activate base
+          source activate base
           python -m pip install -e .
 
     - run:
@@ -41,6 +41,7 @@ shared: &shared
     - run:
         name: Running Tests
         command: |
+          source activate base
           pytest -n 8 --junitxml=test-reports/junit.xml --cov=./ --verbose
     - run:
         name: Uploading code coverage report

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -9,6 +9,7 @@ dependencies:
   - pytest-cov
   - pytest-icdiff
   - pytest-xdist
+  - pytest-sugar
   - pyyaml
   - toolz
   - zarr

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -18,3 +18,4 @@ dependencies:
     - git+https://github.com/intake/filesystem_spec.git
     - git+https://github.com/dask/gcsfs.git
     - git+https://github.com/dask/s3fs.git
+    - git+https://github.com/NCAR/esmcol-validator.git

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -16,3 +16,5 @@ dependencies:
   - s3fs
   - xarray
   - zarr
+  - pip:
+      - esmcol-validator

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - pytest-cov
   - pytest-icdiff
   - pytest-xdist
+  - pytest-sugar
   - pyyaml
   - s3fs
   - xarray

--- a/intake_esm/merge_util.py
+++ b/intake_esm/merge_util.py
@@ -99,7 +99,7 @@ def _aggregate(
             agg_column = agg_columns[level]
 
             agg_info = aggregation_dict[agg_column]
-            agg_type = agg_info['type']
+            agg_type = agg_info['agg_type']
 
             if 'options' in agg_info:
                 agg_options = agg_info['options']

--- a/tests/catalog-dict-records.json
+++ b/tests/catalog-dict-records.json
@@ -70,7 +70,7 @@
         ],
         "aggregations":[
             {
-                "type":"union",
+                "agg_type":"union",
                 "attribute_name":"variable",
                 "options":{
                     "compat":"override"

--- a/tests/cesm1-lens-netcdf.json
+++ b/tests/cesm1-lens-netcdf.json
@@ -38,17 +38,17 @@
       ],
         "aggregations": [
           {
-            "type": "join_new",
+            "agg_type": "join_new",
             "attribute_name": "member_id",
             "options": { "coords": "minimal", "compat": "override"}
           },
           {
-            "type": "join_existing",
+            "agg_type": "join_existing",
             "attribute_name": "time_range",
             "options": { "dim": "time" }
           },
           {
-            "type": "union",
+            "agg_type": "union",
             "attribute_name": "variable"
           }
         ]

--- a/tests/cesm1-lens-zarr.json
+++ b/tests/cesm1-lens-zarr.json
@@ -30,7 +30,7 @@
       ],
         "aggregations": [
           {
-            "type": "union",
+            "agg_type": "union",
             "attribute_name": "variable"
           }
         ]

--- a/tests/cmip5-netcdf.json
+++ b/tests/cmip5-netcdf.json
@@ -44,17 +44,17 @@
       ],
         "aggregations": [
           {
-            "type": "join_new",
+            "agg_type": "join_new",
             "attribute_name": "ensemble_member",
             "options": { "coords": "minimal", "compat": "override"}
           },
           {
-            "type": "join_existing",
+            "agg_type": "join_existing",
             "attribute_name": "time_range",
             "options": { "dim": "time" }
           },
           {
-            "type": "union",
+            "agg_type": "union",
             "attribute_name": "variable"
           }
         ]

--- a/tests/cmip6-netcdf.json
+++ b/tests/cmip6-netcdf.json
@@ -48,17 +48,17 @@
     ],
       "aggregations": [
     {
-      "type": "join_new",
+      "agg_type": "join_new",
       "attribute_name": "member_id",
       "options": { "coords": "minimal", "compat": "override"}
     },
     {
-      "type": "join_existing",
+      "agg_type": "join_existing",
       "attribute_name": "time_range",
       "options": { "dim": "time" }
     },
     {
-      "type": "union",
+      "agg_type": "union",
       "attribute_name": "variable_id"
     }
   ]

--- a/tests/pangeo-cmip6-zarr.json
+++ b/tests/pangeo-cmip6-zarr.json
@@ -55,17 +55,17 @@
     ],
     "aggregations": [
       {
-        "type": "join_new",
+        "agg_type": "join_new",
         "attribute_name": "member_id",
         "options": { "coords": "minimal", "compat": "override" }
       },
       {
-        "type": "join_new",
+        "agg_type": "join_new",
         "attribute_name": "dcpp_init_year",
         "options": { "coords": "minimal", "compat": "override" }
       },
       {
-        "type": "union",
+        "agg_type": "union",
         "attribute_name": "variable_id"
       }
     ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from tempfile import TemporaryDirectory
 
 import intake
@@ -212,3 +213,19 @@ def test_to_dataset_dict_chunking_2(chunks, expected_chunks):
 def test_read_catalog_dict():
     col = intake.open_esm_datastore(catalog_dict_records)
     assert isinstance(col.df, pd.DataFrame)
+
+
+def test_validation():
+    col = intake.open_esm_datastore(cdf_col_sample_cesmle)
+    _, message = col.validate()
+    assert message[0]['valid_esmcol']
+    assert message[0]['valid_esmcat']
+
+
+def test_validation_missing_validator():
+    from unittest import mock
+
+    col = intake.open_esm_datastore(cdf_col_sample_cesmle)
+    with pytest.raises(ImportError):
+        with mock.patch.dict(sys.modules, {'esmcol_validator': None}):
+            _ = col.validate()


### PR DESCRIPTION
Allows the user to validate their collection json file against esm collection spec:

```python
In [1]: import intake                                                                                      

In [2]: col_url = "https://raw.githubusercontent.com/NCAR/intake-esm-datastore/master/catalogs/pangeo-cmip6
   ...: .json"                                                                                             

In [3]: col = intake.open_esm_datastore(col_url)                                                           

In [4]: status, message = col.validate()                                                                   
{'collections': {'valid': 0, 'invalid': 1}, 'catalogs': {'valid': 1, 'invalid': 0}, 'unknown': 0}

In [5]: status                                                                                             
Out[5]: 
{'collections': {'valid': 0, 'invalid': 1},
 'catalogs': {'valid': 1, 'invalid': 0},
 'unknown': 0}

In [6]: message                                                                                            
Out[6]: 
[{'valid_esmcol': False,
  'error_message': "'agg_type' is a required property of ['aggregation_control', 'aggregations', 0]",
  'valid_esmcat': True,
  'cat_error_message': None,
  'path': 'https://raw.githubusercontent.com/NCAR/intake-esm-datastore/master/catalogs/pangeo-cmip6.json'}]

```