### PR TITLE
Add support for wildcards in search() method

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,4 +59,4 @@ jobs:
           python -m pip install isort
       - name: isort check
         run: |
-          isort --recursive --check-only .
+          isort --check-only .

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -756,7 +756,10 @@ def _is_pattern(value):
     if value_is_repattern:
         return True
     wildcard_chars = {'*', '?', '$', '^'}
-    return any(char in value for char in wildcard_chars)
+    try:
+        return any(char in value for char in wildcard_chars)
+    except TypeError:
+        return False
 
 
 def _flatten_list(data):

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -758,7 +758,7 @@ def _is_pattern(value):
     try:
         value_ = value
         for char in wildcard_chars:
-            value_ = value_.replace('\\{0}'.format(char), '')
+            value_ = value_.replace(f'\\{char}', '')
         return any(char in value_ for char in wildcard_chars)
     except (TypeError, AttributeError):
         return False

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -752,13 +752,15 @@ def _normalize_query(query):
 
 
 def _is_pattern(value):
-    value_is_repattern = isinstance(value, Pattern)
-    if value_is_repattern:
+    if isinstance(value, Pattern):
         return True
     wildcard_chars = {'*', '?', '$', '^'}
     try:
-        return any(char in value for char in wildcard_chars)
-    except TypeError:
+        value_ = value
+        for char in wildcard_chars:
+            value_ = value_.replace('\\{0}'.format(char), '')
+        return any(char in value_ for char in wildcard_chars)
+    except (TypeError, AttributeError):
         return False
 
 

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -758,7 +758,7 @@ def _is_pattern(value):
     try:
         value_ = value
         for char in wildcard_chars:
-            value_ = value_.replace(f'\\{char}', '')
+            value_ = value_.replace(fr'\{char}', '')
         return any(char in value_ for char in wildcard_chars)
     except (TypeError, AttributeError):
         return False

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -696,9 +696,9 @@ def _get_subset(df, require_all_on=None, **query):
             df[key].dtype, (np.object, pd.core.arrays.string_.StringDtype)
         )
         for val_i in val:
-            value_is_repattern = isinstance(val_i, Pattern)
-            if column_is_stringtype and value_is_repattern:
-                cond = df[key].str.contains(val_i, regex=True)
+            value_is_pattern = _is_pattern(val_i)
+            if column_is_stringtype and value_is_pattern:
+                cond = df[key].str.contains(val_i, regex=True, case=True, flags=0)
             else:
                 cond = df[key] == val_i
             condition_i |= cond
@@ -749,6 +749,14 @@ def _normalize_query(query):
         if isinstance(val, str) or not isinstance(val, Iterable):
             q[key] = [val]
     return q
+
+
+def _is_pattern(value):
+    value_is_repattern = isinstance(value, Pattern)
+    if value_is_repattern:
+        return True
+    wildcard_chars = {'*', '?', '$', '^'}
+    return any(char in value for char in wildcard_chars)
 
 
 def _flatten_list(data):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -401,6 +401,15 @@ params = [
             {'A': 'NCAR', 'B': 'CESM', 'C': 'control', 'D': 'O2'},
         ],
     ),
+    (
+        {'C': ['^co.*ol$']},
+        None,
+        [
+            {'A': 'IPSL', 'B': 'FOO', 'C': 'control', 'D': 'O2'},
+            {'A': 'CSIRO', 'B': 'BAR', 'C': 'control', 'D': 'O2'},
+            {'A': 'NCAR', 'B': 'CESM', 'C': 'control', 'D': 'O2'},
+        ],
+    ),
     ({'C': ['hist'], 'D': ['TA']}, None, [{'A': 'NCAR', 'B': 'WACM', 'C': 'hist', 'D': 'TA'}],),
     (
         {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -457,6 +457,7 @@ def test_normalize_query():
         (2, False),
         ('foo', False),
         ('foo\\*bar', False),
+        (r'foo\*bar*', True),
         ('^foo', True),
         ('^foo.*bar$', True),
         (re.compile('hist.*', flags=re.IGNORECASE), True),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -456,6 +456,7 @@ def test_normalize_query():
     [
         (2, False),
         ('foo', False),
+        ('foo\\*bar', False),
         ('^foo', True),
         ('^foo.*bar$', True),
         (re.compile('hist.*', flags=re.IGNORECASE), True),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -456,6 +456,9 @@ def test_normalize_query():
     [
         (2, False),
         ('foo', False),
+        ('foo\\**bar', True),
+        ('foo\\?*bar', True),
+        ('foo\\?\\*bar', False),
         ('foo\\*bar', False),
         (r'foo\*bar*', True),
         ('^foo', True),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,7 @@ import pytest
 import xarray as xr
 
 import intake_esm
-from intake_esm.core import _get_subset, _normalize_query, _unique
+from intake_esm.core import _get_subset, _is_pattern, _normalize_query, _unique
 
 here = os.path.abspath(os.path.dirname(__file__))
 zarr_col_pangeo_cmip6 = (
@@ -449,3 +449,17 @@ def test_normalize_query():
     }
     actual = _normalize_query(query)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'value, expected',
+    [
+        (2, False),
+        ('foo', False),
+        ('^foo', True),
+        ('^foo.*bar$', True),
+        (re.compile('hist.*', flags=re.IGNORECASE), True),
+    ],
+)
+def test_is_pattern(value, expected):
+    assert _is_pattern(value) == expected


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist

- [x] Passes `pre-commit run --all-files`
- [x] Tests added / passed

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is meant to complement #236 

```python
In [4]: col = intake.open_esm_datastore(url)                                  

In [5]: col.search(long_name='^Wind.*direction$').df.head()                   
Out[5]: 
  component  ...                                               path
0       ocn  ...  s3://ncar-cesm-lens/ocn/monthly/cesmLE-20C-TAU...
1       ocn  ...  s3://ncar-cesm-lens/ocn/monthly/cesmLE-RCP85-T...
2       ocn  ...  s3://ncar-cesm-lens/ocn/monthly/cesmLE-CTRL-TA...
3       ocn  ...  s3://ncar-cesm-lens/ocn/monthly/cesmLE-20C-TAU...
4       ocn  ...  s3://ncar-cesm-lens/ocn/monthly/cesmLE-RCP85-T...

[5 rows x 9 columns]
```

Cc @markusritschel, @jeffdlb