### PR TITLE
Fix TypeError bug in `search()` when using wildcard and regular expressions

### DIFF
--- a/intake_esm/search.py
+++ b/intake_esm/search.py
@@ -57,8 +57,8 @@ def search(df, require_all_on=None, **query):
                 cond = df[key].str.contains(val_i, regex=True, case=True, flags=0)
             else:
                 cond = df[key] == val_i
-            condition_i |= cond
-        condition &= condition_i
+            condition_i = condition_i | cond
+        condition = condition & condition_i
     query_results = df.loc[condition]
 
     if require_all_on:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist

- [x] Passes `pre-commit run --all-files`
- [x] Tests added / passed

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This meant to address this issue

```python
In [7]: query = dict(variable=['TAUX*'])

In [8]: col.search(**query)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-8-2096e4b5617a> in <module>
----> 1 col.search(**query)

~/devel/intake/intake-esm/intake_esm/core.py in search(self, require_all_on, **query)
    652         """
    653
--> 654         results = search(self.df, require_all_on=require_all_on, **query)
    655         ret = esm_datastore.from_df(
    656             results,

~/devel/intake/intake-esm/intake_esm/search.py in search(df, require_all_on, **query)
     58             else:
     59                 cond = df[key] == val_i
---> 60             condition_i |= cond
     61         condition &= condition_i
     62     query_results = df.loc[condition]

~/opt/miniconda3/envs/intake-esm-dev/lib/python3.8/site-packages/pandas/core/series.py in __array_ufunc__(self, ufunc, method, *inputs, **kwargs)
    724
    725         inputs = tuple(extract_array(x, extract_numpy=True) for x in inputs)
--> 726         result = getattr(ufunc, method)(*inputs, **kwargs)
    727
    728         name = names[0] if len(set(names)) == 1 else None

TypeError: ufunc 'bitwise_or' output (typecode 'O') could not be coerced to provided output parameter (typecode '?') according to the casting rule ''same_kind''
```
