### PR TITLE
Use pydantic.validate_arguments decorator to validate individual functions

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -130,6 +130,7 @@ class esm_datastore(Catalog):
             _ = self[key]
         return self._entries
 
+    @pydantic.validate_arguments
     def __getitem__(self, key: str) -> ESMDataSource:
         """
         This method takes a key argument and return a data source
@@ -237,9 +238,10 @@ class esm_datastore(Catalog):
     def _ipython_key_completions_(self):
         return self.__dir__()
 
+    @pydantic.validate_arguments
     def search(
-        self, require_all_on: typing.Union[str, typing.List[str]] = None, **query
-    ) -> 'esm_datastore':
+        self, require_all_on: typing.Union[str, typing.List[str]] = None, **query: typing.Any
+    ):
         """Search for entries in the catalog.
 
         Parameters
@@ -307,7 +309,13 @@ class esm_datastore(Catalog):
         cat._requested_variables = requested_variables
         return cat
 
-    def serialize(self, name: str, directory: str = None, catalog_type: str = 'dict') -> None:
+    @pydantic.validate_arguments
+    def serialize(
+        self,
+        name: pydantic.StrictStr,
+        directory: typing.Union[pydantic.DirectoryPath, pydantic.StrictStr] = None,
+        catalog_type: str = 'dict',
+    ) -> None:
         """Serialize collection/catalog to corresponding json and csv files.
 
         Parameters
@@ -369,14 +377,15 @@ class esm_datastore(Catalog):
 
         return self.esmcat.unique()
 
+    @pydantic.validate_arguments
     def to_dataset_dict(
         self,
         xarray_open_kwargs: typing.Dict[str, typing.Any] = None,
         xarray_combine_by_coords_kwargs: typing.Dict[str, typing.Any] = None,
-        preprocess: typing.Dict[str, typing.Any] = None,
-        storage_options: typing.Dict[str, typing.Any] = None,
-        progressbar: bool = None,
-        aggregate: bool = None,
+        preprocess: typing.Callable = None,
+        storage_options: typing.Dict[pydantic.StrictStr, typing.Any] = None,
+        progressbar: pydantic.StrictBool = None,
+        aggregate: pydantic.StrictBool = None,
         **kwargs,
     ) -> typing.Dict[str, xr.Dataset]:
         """
@@ -475,9 +484,6 @@ class esm_datastore(Catalog):
 
         if progressbar is not None:
             self.progressbar = progressbar
-
-        if preprocess is not None and not callable(preprocess):
-            raise ValueError('preprocess argument must be callable')
 
         if self.progressbar:
             print(

--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -99,6 +99,7 @@ class ESMDataSource(DataSource):
     name = 'esm_datasource'
     partition_access = True
 
+    @pydantic.validate_arguments
     def __init__(
         self,
         key: pydantic.StrictStr,
@@ -114,7 +115,7 @@ class ESMDataSource(DataSource):
         xarray_open_kwargs: typing.Dict[str, typing.Any] = None,
         xarray_combine_by_coords_kwargs: typing.Dict[str, typing.Any] = None,
         intake_kwargs: typing.Dict[str, typing.Any] = None,
-    ) -> 'ESMDataSource':
+    ):
 
         intake_kwargs = intake_kwargs or {}
         super().__init__(**intake_kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ netCDF4>=1.5.5
 requests>=2.24.0
 xarray>=0.19
 zarr>=2.5
-pydantic
+pydantic>=1.8.2

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ import ast
 
 import intake
 import pandas as pd
+import pydantic
 import pytest
 import xarray as xr
 
@@ -257,5 +258,5 @@ def test_to_dataset_dict_cdf_zarr_kwargs_deprecation():
 
 def test_to_dataset_dict_w_preprocess_error():
     cat = intake.open_esm_datastore(cdf_col_sample_cmip5)
-    with pytest.raises(ValueError, match=r'preprocess argument must be callable'):
+    with pytest.raises(pydantic.ValidationError):
         cat.to_dataset_dict(preprocess='foo')


### PR DESCRIPTION

<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Decorates some functions with `@pydantic.validate_arguments`. This allows to check types for standalone functions without needing to build an entire model. 


<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
