### PR TITLE
Add method for loading registry from a Python module

### DIFF
--- a/tests/my_registry.py
+++ b/tests/my_registry.py
@@ -1,0 +1,8 @@
+import intake_esm
+
+registry = intake_esm.DerivedVariableRegistry()
+
+
+@registry.register(variable='FOO', dependent_variables=['FLUT'])
+def func(ds):
+    return ds

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -1,7 +1,11 @@
+import sys
+
 import pytest
 import xarray as xr
 
 from intake_esm.derived import DerivedVariable, DerivedVariableError, DerivedVariableRegistry
+
+from .utils import here
 
 
 def test_registry_init():
@@ -12,6 +16,18 @@ def test_registry_init():
 
     assert dvr._registry == {}
     assert len(dvr.keys()) == 0
+
+
+def test_registry_load():
+
+    sys.path.insert(0, f'{here}/')
+    dvr = DerivedVariableRegistry.load('my_registry')
+    assert len(dvr) > 0
+    assert 'FOO' in dvr
+
+    # Test for errors/ invalid inputs, wrong return type
+    with pytest.raises(ValueError):
+        DerivedVariableRegistry.load('utils')
 
 
 def test_registry_register():


### PR DESCRIPTION

<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

- Towards https://github.com/intake/intake-esm/issues/384
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
