### PR TITLE
Properly check whether dataframe is empty

### DIFF
--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -315,7 +315,7 @@ class ESMCatalogModel(pydantic.BaseModel):
         results = search(
             df=self.df, query=_query.query, columns_with_iterables=self.columns_with_iterables
         )
-        if _query.require_all_on is not None and results:
+        if _query.require_all_on is not None and not results.empty:
             results = search_apply_require_all_on(
                 df=results, query=_query.query, require_all_on=_query.require_all_on
             )


### PR DESCRIPTION

<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Fixes `valueError` when checking whether the dataframe is empty 

```python
--> 323         esmcat_results = self.esmcat.search(require_all_on=require_all_on, query=query)
    324 
    325         # step 2: Search for entries required to derive variables in the derived catalogs

/glade/work/abanihi/devel/intake/intake-esm/intake_esm/cat.py in search(self, query, require_all_on)
    316             df=self.df, query=_query.query, columns_with_iterables=self.columns_with_iterables
    317         )
--> 318         if _query.require_all_on is not None and results:
    319             results = search_apply_require_all_on(
    320                 df=results, query=_query.query, require_all_on=_query.require_all_on

/glade/work/abanihi/opt/miniconda/envs/playground/lib/python3.8/site-packages/pandas/core/generic.py in __nonzero__(self)
   1535     @final
   1536     def __nonzero__(self):
-> 1537         raise ValueError(
   1538             f"The truth value of a {type(self).__name__} is ambiguous. "
   1539             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."

ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
