### PR TITLE
Add `to_dask()` method to `esm_datastore`

### DIFF
--- a/docs/source/user-guide/overview.ipynb
+++ b/docs/source/user-guide/overview.ipynb
@@ -286,6 +286,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case you can formulate your search such that it returns only a single dataset as a result, there's a shortcut to obtain this dataset using `to_dask` directly on the search result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = col.search(component=[\"lnd\"], frequency=[\"monthly\"], experiment=[\"20C\"]).to_dask()"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -593,7 +593,7 @@ class esm_datastore(Catalog):
         if len(res) != 1:  # extra check in case kwargs did modify something
             raise ValueError(f'Expected exactly one dataset. Received {len(self)} datasets. Please refine your search or use `.to_dataset_dict()`.')
        _, ds = res.popitem()
-       return ds 
+       return ds
 
     def _create_derived_variables(self, datasets, skip_on_error):
         if len(self.derivedcat) > 0:

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -572,9 +572,7 @@ class esm_datastore(Catalog):
         self.datasets = self._create_derived_variables(datasets, skip_on_error)
         return self.datasets
 
-    def to_dask(
-        self,
-        **kwargs) -> xr.Dataset:
+    def to_dask(self, **kwargs) -> xr.Dataset:
         """
         Convert result to dataset.
 
@@ -589,10 +587,10 @@ class esm_datastore(Catalog):
         :py:class:`~xarray.Dataset`
         """
         if len(self) != 1:  # quick check to fail more quickly if there are many results
-            raise ValueError("not exactly one result")
-        res = self.to_dataset_dict(**{**kwargs, "progressbar": False})
+            raise ValueError('not exactly one result')
+        res = self.to_dataset_dict(**{**kwargs, 'progressbar': False})
         if len(res) != 1:  # extra check in case kwargs did modify something
-            raise ValueError("not exactly one result")
+            raise ValueError('not exactly one result')
         return next(iter(res.values()))
 
     def _create_derived_variables(self, datasets, skip_on_error):

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -572,6 +572,29 @@ class esm_datastore(Catalog):
         self.datasets = self._create_derived_variables(datasets, skip_on_error)
         return self.datasets
 
+    def to_dask(
+        self,
+        **kwargs) -> xr.Dataset:
+        """
+        Convert result to dataset.
+
+        This is only possible if the search returned exactly one result.
+
+        Parameters
+        ----------
+        all parameters are forwarded to :py:method:`to_dataset_dict()`.
+
+        Returns
+        -------
+        :py:class:`~xarray.Dataset`
+        """
+        if len(self) != 1:  # quick check to fail more quickly if there are many results
+            raise ValueError("not exactly one result")
+        res = self.to_dataset_dict(**{**kwargs, "progressbar": False})
+        if len(res) != 1:  # extra check in case kwargs did modify something
+            raise ValueError("not exactly one result")
+        return next(iter(res.values()))
+
     def _create_derived_variables(self, datasets, skip_on_error):
         if len(self.derivedcat) > 0:
             datasets = self.derivedcat.update_datasets(

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -581,7 +581,7 @@ class esm_datastore(Catalog):
 
         Parameters
         ----------
-        all parameters are forwarded to :py:method:`to_dataset_dict()`.
+        all parameters are forwarded to :py:func:`~intake_esm.esm_datastore.to_dataset_dict`.
 
         Returns
         -------

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -588,11 +588,12 @@ class esm_datastore(Catalog):
         :py:class:`~xarray.Dataset`
         """
         if len(self) != 1:  # quick check to fail more quickly if there are many results
-            raise ValueError('not exactly one result')
+            raise ValueError(f'Expected exactly one dataset. Received {len(self)} datasets. Please refine your search or use `.to_dataset_dict()`.')
         res = self.to_dataset_dict(**{**kwargs, 'progressbar': False})
         if len(res) != 1:  # extra check in case kwargs did modify something
-            raise ValueError('not exactly one result')
-        return next(iter(res.values()))
+            raise ValueError(f'Expected exactly one dataset. Received {len(self)} datasets. Please refine your search or use `.to_dataset_dict()`.')
+       _, ds = res.popitem()
+       return ds 
 
     def _create_derived_variables(self, datasets, skip_on_error):
         if len(self.derivedcat) > 0:

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -247,6 +247,7 @@ class esm_datastore(Catalog):
         rv = [
             'df',
             'to_dataset_dict',
+            'to_dask',
             'keys',
             'serialize',
             'datasets',

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -592,8 +592,8 @@ class esm_datastore(Catalog):
         res = self.to_dataset_dict(**{**kwargs, 'progressbar': False})
         if len(res) != 1:  # extra check in case kwargs did modify something
             raise ValueError(f'Expected exactly one dataset. Received {len(self)} datasets. Please refine your search or use `.to_dataset_dict()`.')
-       _, ds = res.popitem()
-       return ds
+        _, ds = res.popitem()
+        return ds
 
     def _create_derived_variables(self, datasets, skip_on_error):
         if len(self.derivedcat) > 0:

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -588,10 +588,14 @@ class esm_datastore(Catalog):
         :py:class:`~xarray.Dataset`
         """
         if len(self) != 1:  # quick check to fail more quickly if there are many results
-            raise ValueError(f'Expected exactly one dataset. Received {len(self)} datasets. Please refine your search or use `.to_dataset_dict()`.')
+            raise ValueError(
+                f'Expected exactly one dataset. Received {len(self)} datasets. Please refine your search or use `.to_dataset_dict()`.'
+            )
         res = self.to_dataset_dict(**{**kwargs, 'progressbar': False})
         if len(res) != 1:  # extra check in case kwargs did modify something
-            raise ValueError(f'Expected exactly one dataset. Received {len(self)} datasets. Please refine your search or use `.to_dataset_dict()`.')
+            raise ValueError(
+                f'Expected exactly one dataset. Received {len(self)} datasets. Please refine your search or use `.to_dataset_dict()`.'
+            )
         _, ds = res.popitem()
         return ds
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -240,6 +240,36 @@ def test_to_dataset_dict(path, query, xarray_open_kwargs):
     assert len(ds.__dask_keys__()) > 0
     assert ds.time.encoding
 
+@pytest.mark.parametrize(
+    'path, query, xarray_open_kwargs',
+    [
+        (
+            zarr_col_pangeo_cmip6,
+            dict(
+                variable_id=['pr'],
+                experiment_id='ssp370',
+                activity_id='AerChemMIP',
+                source_id='BCC-ESM1',
+                table_id='Amon',
+                grid_label='gn',
+            ),
+            {'consolidated': True, 'backend_kwargs': {'storage_options': {'token': 'anon'}}},
+        ),
+        (
+            cdf_col_sample_cmip6,
+            dict(source_id=['CNRM-ESM2-1', 'CNRM-CM6-1', 'BCC-ESM1'], variable_id=['tasmax']),
+            {'chunks': {'time': 1}},
+        ),
+    ],
+)
+def test_to_dask(path, query, xarray_open_kwargs):
+    cat = intake.open_esm_datastore(path)
+    cat_sub = cat.search(**query)
+    ds = cat_sub.to_dask(xarray_open_kwargs=xarray_open_kwargs)
+    assert 'member_id' in ds.dims
+    assert len(ds.__dask_keys__()) > 0
+    assert ds.time.encoding
+
 
 @pytest.mark.parametrize(
     'path, query',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -240,6 +240,7 @@ def test_to_dataset_dict(path, query, xarray_open_kwargs):
     assert len(ds.__dask_keys__()) > 0
     assert ds.time.encoding
 
+
 @pytest.mark.parametrize(
     'path, query, xarray_open_kwargs',
     [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -258,7 +258,11 @@ def test_to_dataset_dict(path, query, xarray_open_kwargs):
         ),
         (
             cdf_col_sample_cmip6,
-            dict(source_id=['CNRM-ESM2-1', 'CNRM-CM6-1', 'BCC-ESM1'], variable_id=['tasmax']),
+            dict(
+                source_id=['CNRM-ESM2-1', 'CNRM-CM6-1', 'BCC-ESM1'],
+                variable_id=['tasmax'],
+                experiment_id='piControl',
+            ),
             {'chunks': {'time': 1}},
         ),
     ],


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

This adds `esm_datastore.to_dask()` as discussed in #401 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

closes #401

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
