### PR TITLE
Support mixed data formats

### DIFF
--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -42,7 +42,7 @@ class Attribute(pydantic.BaseModel):
 
 class Assets(pydantic.BaseModel):
     column_name: pydantic.StrictStr
-    format: DataFormat
+    format: typing.Optional[DataFormat]
     format_column_name: typing.Optional[pydantic.StrictStr]
 
     class Config:
@@ -54,6 +54,8 @@ class Assets(pydantic.BaseModel):
         data_format, format_column_name = values.get('format'), values.get('format_column_name')
         if data_format is not None and format_column_name is not None:
             raise ValueError('Cannot set both format and format_column_name')
+        elif data_format is None and format_column_name is None:
+            raise ValueError('Must set one of format or format_column_name')
         return values
 
 

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -202,6 +202,7 @@ class esm_datastore(Catalog):
                     variable_column_name=self.esmcat.aggregation_control.variable_column_name,
                     path_column_name=self.esmcat.assets.column_name,
                     data_format=self.esmcat.assets.format,
+                    format_column_name=self.esmcat.assets.format_column_name,
                     aggregations=self.esmcat.aggregation_control.aggregations,
                     intake_kwargs={'metadata': {}},
                 )

--- a/tests/sample-collections/cmip6-bcc-mixed-formats.csv
+++ b/tests/sample-collections/cmip6-bcc-mixed-formats.csv
@@ -1,0 +1,5 @@
+activity_id,institution_id,source_id,experiment_id,member_id,table_id,variable_id,grid_label,format,path,time_range,dcpp_init_year
+CMIP,BCC,BCC-ESM1,piControl,r1i1p1f1,Amon,tasmax,gn,netcdf,./tests/sample_data/cmip/CMIP6/CMIP/BCC/BCC-ESM1/piControl/r1i1p1f1/Amon/tasmax/gn/v20181214/tasmax/tasmax_Amon_BCC-ESM1_piControl_r1i1p1f1_gn_185001-230012.nc,185001-230012,
+CMIP,BCC,BCC-ESM1,piControl,r1i1p1f1,Amon,tasmin,gn,zarr,gs://cmip6/CMIP6/CMIP/BCC/BCC-ESM1/piControl/r1i1p1f1/Amon/tasmin/gn/v20181214/,185001-230012,
+CMIP,BCC,BCC-CSM2-MR,abrupt-4xCO2,r1i1p1f1,Amon,tasmax,gn,netcdf,./tests/sample_data/cmip/CMIP6/CMIP/BCC/BCC-CSM2-MR/abrupt-4xCO2/r1i1p1f1/Amon/tasmax/gn/v20181016/tasmax/tasmax_Amon_BCC-CSM2-MR_abrupt-4xCO2_r1i1p1f1_gn_185001-200012.nc,185001-200012,
+CMIP,BCC,BCC-CSM2-MR,abrupt-4xCO2,r1i1p1f1,Amon,tasmin,gn,zarr,gs://cmip6/CMIP6/CMIP/BCC/BCC-CSM2-MR/abrupt-4xCO2/r1i1p1f1/Amon/tasmin/gn/v20181016/,185001-200012,

--- a/tests/sample-collections/cmip6-bcc-mixed-formats.json
+++ b/tests/sample-collections/cmip6-bcc-mixed-formats.json
@@ -1,0 +1,66 @@
+{
+  "esmcat_version": "0.1.0",
+  "id": "sample-cmip6-mixed",
+  "description": "This is a sample ESM collection for CMIP6 data in netcdf AND zarr format, local and remote.",
+  "catalog_file": "cmip6-bcc-mixed-formats.csv",
+  "attributes": [
+    {
+      "column_name": "activity_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_activity_id.json"
+    },
+    {
+      "column_name": "source_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_source_id.json"
+    },
+    {
+      "column_name": "institution_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_institution_id.json"
+    },
+    {
+      "column_name": "experiment_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_experiment_id.json"
+    },
+    { "column_name": "member_id", "vocabulary": "" },
+    {
+      "column_name": "table_id",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_table_id.json"
+    },
+    { "column_name": "variable_id", "vocabulary": "" },
+    {
+      "column_name": "grid_label",
+      "vocabulary": "https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/master/CMIP6_grid_label.json"
+    }
+  ],
+  "assets": {
+    "column_name": "path",
+    "format_column_name": "format"
+  },
+
+  "aggregation_control": {
+    "variable_column_name": "variable_id",
+    "groupby_attrs": [
+      "activity_id",
+      "institution_id",
+      "source_id",
+      "experiment_id",
+      "table_id",
+      "grid_label"
+    ],
+    "aggregations": [
+      {
+        "type": "join_new",
+        "attribute_name": "member_id",
+        "options": { "coords": "minimal", "compat": "override" }
+      },
+      {
+        "type": "join_existing",
+        "attribute_name": "time_range",
+        "options": { "dim": "time" }
+      },
+      {
+        "type": "union",
+        "attribute_name": "variable_id"
+      }
+    ]
+  }
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,6 +27,7 @@ from .utils import (
     cdf_col_sample_cesmle,
     cdf_col_sample_cmip5,
     cdf_col_sample_cmip6,
+    mixed_col_sample_cmip6,
     multi_variable_col,
     sample_df,
     sample_esmcol_data,
@@ -231,6 +232,7 @@ def test_multi_variable_catalog(query):
             dict(source_id=['CNRM-ESM2-1', 'CNRM-CM6-1', 'BCC-ESM1'], variable_id=['tasmax']),
             {'chunks': {'time': 1}},
         ),
+        (mixed_col_sample_cmip6, dict(institution_id='BCC'), {}),
     ],
 )
 def test_to_dataset_dict(path, query, xarray_open_kwargs):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,7 @@ catalog_dict_records = os.path.join(here, 'sample-collections/catalog-dict-recor
 zarr_col_aws_cesm = (
     'https://raw.githubusercontent.com/NCAR/cesm-lens-aws/master/intake-catalogs/aws-cesm1-le.json'
 )
+mixed_col_sample_cmip6 = os.path.join(here, 'sample-collections/cmip6-bcc-mixed-formats.json')
 
 
 sample_df = pd.DataFrame(


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->
- Made `Assets.format` optional
- Added `format_column_name` to `ESMDataSource`'s init
- Format information is added a column on `ESMDataSource`'s internal df. `xarray_open_kwargs` are generated independently for each assets (instead of only once).

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
- Fixes #414 
## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->

To make this PR simple, I decided to use an hardcoded name for the new column (`_data_format_`). Is this dangerous? It could be a column name stored in another variable, or the series could be independent from the main dataframe? The latter seems dangerous too.

I added a sample collection that has 4 assets of CMIP6. 2 assets are from Google Storage (zarr) and the 2 others  are local files. This has the bonus to also test that `to_dataset_dict` also works with remote and local assets _within the same dataset_.