### PR TITLE
Search returns same class as self - allowing subclassing

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -344,7 +344,7 @@ class esm_datastore(Catalog):
                 .reset_index(drop=True)
             )
 
-        cat = esm_datastore({'esmcat': self.esmcat.dict(), 'df': esmcat_results})
+        cat = self.__class__({'esmcat': self.esmcat.dict(), 'df': esmcat_results})
         if self.esmcat.has_multiple_variable_assets:
             requested_variables = query.get(
                 self.esmcat.aggregation_control.variable_column_name, []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -414,7 +414,6 @@ def test_to_dataset_dict_with_registry():
 
 
 def test_subclassing_catalog():
-
     class ChildCatalog(intake_esm.esm_datastore):
         pass
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -411,3 +411,13 @@ def test_to_dataset_dict_with_registry():
         new_cat.to_dataset_dict(
             xarray_open_kwargs={'backend_kwargs': {'storage_options': {'anon': True}}}
         )
+
+
+def test_subclassing_catalog():
+
+    class ChildCatalog(intake_esm.esm_datastore):
+        pass
+
+    cat = ChildCatalog(catalog_dict_records)
+    scat = cat.search(variable=['FOO', 'BAR'])
+    assert type(scat) is ChildCatalog


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary
- In `esm_datastore.search` the result is instantiated from the same class as `self`, allowing subclassing.
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
- Fixes #415

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
Should I add a unit test for this? It's not something I ever tested in other projects. I mean `intake_esm` does not have subclasses of `esm_datastore` thus testing this feature is somewhat out of scope? I can quickly add a basic one if you prefer.