### PR TITLE
Improve search with derived variables

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -331,6 +331,8 @@ class esm_datastore(Catalog):
         derivedcat_results = []
         variables = query.pop(self.esmcat.aggregation_control.variable_column_name, None)
         if variables:
+            if isinstance(variables, str):
+                variables = [variables]
             dependents = []
             for key, value in self.derivedcat.items():
                 if key in variables:

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -329,13 +329,23 @@ class esm_datastore(Catalog):
         # step 2: Search for entries required to derive variables in the derived catalogs
         # This requires a bit of a hack i.e. the user has to specify the variable in the query
         derivedcat_results = []
-        variables = query.get(self.esmcat.aggregation_control.variable_column_name, [])
+        variables = query.pop(self.esmcat.aggregation_control.variable_column_name, None)
         if variables:
+            dependents = []
             for key, value in self.derivedcat.items():
                 if key in variables:
-                    derivedcat_results.append(
-                        self.esmcat.search(require_all_on=require_all_on, query=value.query)
+                    res = self.esmcat.search(
+                        require_all_on=require_all_on, query={**value.query, **query}
                     )
+                    if not res.empty:
+                        derivedcat_results.append(res)
+                        dependents.extend(
+                            value.dependent_variables(
+                                self.esmcat.aggregation_control.variable_column_name
+                            )
+                        )
+            # Update variable list with dependent variables.
+            variables = list(set(variables).union(dependents))
 
         if derivedcat_results:
             # Merge results from the main and the derived catalogs
@@ -347,16 +357,18 @@ class esm_datastore(Catalog):
 
         cat = self.__class__({'esmcat': self.esmcat.dict(), 'df': esmcat_results})
         if self.esmcat.has_multiple_variable_assets:
-            requested_variables = query.get(
-                self.esmcat.aggregation_control.variable_column_name, []
-            )
+            requested_variables = variables or []
         else:
             requested_variables = []
         cat._requested_variables = requested_variables
 
-        # step 3: Subset the derived catalog
-        derivat_cat_subset = self.derivedcat.search(variable=variables)
-        cat.derivedcat = derivat_cat_subset
+        # step 3: Subset the derived catalog,
+        # but only if variables were looked up, otherwise transfer the whole catalog.
+        if variables is not None:
+            derivat_cat_subset = self.derivedcat.search(variable=variables)
+            cat.derivedcat = derivat_cat_subset
+        else:
+            cat.derivedcat = self.derivedcat
         return cat
 
     @pydantic.validate_arguments

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -244,7 +244,7 @@ def test_multi_variable_catalog_derived_cat():
         read_csv_kwargs={'converters': {'variable': ast.literal_eval}},
         registry=registry_multivar,
     )
-    cat_sub = cat.search(variable='FOO')
+    cat_sub = cat.search(variable=['FOO'])
     assert set(cat_sub._requested_variables) == {'TEMP', 'FOO'}
 
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->
- Non-variable query terms are repeated when searching the catalog with dependent variables.
- When dependent variables are found, they are added to the variable list that may be sent to the "requested_variables" attribute of the "child" catalog.
- The derived variable registry is only subsetted if variables were requested in the query. Otherwise, the full DVR is given to the "child" catalog.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #427

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
I'll try to find time to add unit tests, but that might be in january, sorry. I wanted to open the PR first to see people's thoughts.