### PR TITLE
Support iterable columns with `require_all_on`

### DIFF
--- a/intake_esm/_search.py
+++ b/intake_esm/_search.py
@@ -4,6 +4,8 @@ import typing
 import numpy as np
 import pandas as pd
 
+from .utils import unpack_iterable_column
+
 
 def is_pattern(value):
     if isinstance(value, typing.Pattern):
@@ -50,6 +52,7 @@ def search_apply_require_all_on(
     df: pd.DataFrame,
     query: typing.Dict[str, typing.Any],
     require_all_on: typing.Union[str, typing.List[typing.Any]],
+    columns_with_iterables: set = None,
 ) -> pd.DataFrame:
     _query = query.copy()
     # Make sure to remove columns that were already
@@ -66,12 +69,17 @@ def search_apply_require_all_on(
     condition = set(itertools.product(*values))
     query_results = []
     for _, group in grouped:
-        index = group.set_index(keys).index
+        group_for_index = group
+        # Unpack iterables to get testable index.
+        for column in (columns_with_iterables or set()).intersection(keys):
+            group_for_index = unpack_iterable_column(group_for_index, column)
+
+        index = group_for_index.set_index(keys).index
         if not isinstance(index, pd.MultiIndex):
             index = {(element,) for element in index.to_list()}
         else:
             index = set(index.to_list())
-        if index == condition:
+        if condition.issubset(index):  # with iterables we could have more then requested
             query_results.append(group)
 
     if query_results:

--- a/intake_esm/_search.py
+++ b/intake_esm/_search.py
@@ -4,7 +4,16 @@ import typing
 import numpy as np
 import pandas as pd
 
-from .utils import unpack_iterable_column
+
+def unpack_iterable_column(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Return a DataFrame where elements of a given iterable column have been unpacked into multiple lines."""
+    rows = []
+    for _, row in df.iterrows():
+        for val in row[column]:
+            new_row = row.copy()
+            new_row[column] = val
+            rows.append(new_row)
+    return pd.DataFrame(rows)
 
 
 def is_pattern(value):

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -356,7 +356,10 @@ class ESMCatalogModel(pydantic.BaseModel):
         )
         if _query.require_all_on is not None and not results.empty:
             results = search_apply_require_all_on(
-                df=results, query=_query.query, require_all_on=_query.require_all_on
+                df=results,
+                query=_query.query,
+                require_all_on=_query.require_all_on,
+                columns_with_iterables=self.columns_with_iterables,
             )
         return results
 

--- a/intake_esm/utils.py
+++ b/intake_esm/utils.py
@@ -2,22 +2,9 @@
 import importlib
 import sys
 
-import pandas as pd
-
 INTAKE_ESM_ATTRS_PREFIX = 'intake_esm_attrs'
 INTAKE_ESM_DATASET_KEY = 'intake_esm_dataset_key'
 INTAKE_ESM_VARS_KEY = 'intake_esm_vars'
-
-
-def unpack_iterable_column(df: pd.DataFrame, column: str) -> pd.DataFrame:
-    """Return a DataFrame where elements of a given iterable column have been unpacked into multiple lines."""
-    rows = []
-    for i, row in df.iterrows():
-        for val in row[column]:
-            new_row = row.copy()
-            new_row[column] = val
-            rows.append(new_row)
-    return pd.DataFrame(rows)
 
 
 def _allnan_or_nonan(df, column: str) -> bool:

--- a/intake_esm/utils.py
+++ b/intake_esm/utils.py
@@ -2,9 +2,22 @@
 import importlib
 import sys
 
+import pandas as pd
+
 INTAKE_ESM_ATTRS_PREFIX = 'intake_esm_attrs'
 INTAKE_ESM_DATASET_KEY = 'intake_esm_dataset_key'
 INTAKE_ESM_VARS_KEY = 'intake_esm_vars'
+
+
+def unpack_iterable_column(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Return a DataFrame where elements of a given iterable column have been unpacked into multiple lines."""
+    rows = []
+    for i, row in df.iterrows():
+        for val in row[column]:
+            new_row = row.copy()
+            new_row[column] = val
+            rows.append(new_row)
+    return pd.DataFrame(rows)
 
 
 def _allnan_or_nonan(df, column: str) -> bool:


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary
I added a small function to "unpack" the iterable columns into multiple lines, this way the "index" used to check for the "require_all_on" condition is populated with the real elements to compare, not the iterables of elements.

## Related issue number
Fixes #434
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

