### PR TITLE
Remove unused `@df.setter`

### DIFF
--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -93,9 +93,11 @@ class ESMCatalogModel(pydantic.BaseModel):
     catalog_file: pydantic.StrictStr = None
     description: pydantic.StrictStr = None
     title: pydantic.StrictStr = None
-    _df: typing.Optional[typing.Any] = pydantic.PrivateAttr()
+    _df: typing.Optional[pd.DataFrame] = None
 
     class Config:
+        arbitrary_types_allowed = True
+        underscore_attrs_are_private = True
         validate_all = True
         validate_assignment = True
 
@@ -243,18 +245,14 @@ class ESMCatalogModel(pydantic.BaseModel):
         return {column for column, check in has_iterables.items() if check}
 
     @property
-    def has_multiple_variable_assets(self) -> bool:
-        """Return True if the catalog has multiple variable assets."""
-        return self.aggregation_control.variable_column_name in self.columns_with_iterables
-
-    @property
     def df(self) -> pd.DataFrame:
         """Return the dataframe."""
         return self._df
 
-    @df.setter
-    def df(self, value: pd.DataFrame) -> None:
-        self._df = value
+    @property
+    def has_multiple_variable_assets(self) -> bool:
+        """Return True if the catalog has multiple variable assets."""
+        return self.aggregation_control.variable_column_name in self.columns_with_iterables
 
     def _cast_agg_columns_with_iterables(self) -> None:
         """Cast all agg_columns with iterables to tuple values so as

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -93,7 +93,7 @@ class ESMCatalogModel(pydantic.BaseModel):
     catalog_file: pydantic.StrictStr = None
     description: pydantic.StrictStr = None
     title: pydantic.StrictStr = None
-    _df: typing.Optional[pd.DataFrame] = None
+    _df: typing.Optional[pd.DataFrame] = pydantic.PrivateAttr()
 
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

The `@df.setter` method isn't used/allowed by Pydantic. This PR removes it. 

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-78-2517183ee52f> in <module>
----> 1 cat.df = None

/glade/work/abanihi/opt/miniconda/envs/ecgtools-dev/lib/python3.9/site-packages/pydantic/main.cpython-39-x86_64-linux-gnu.so in pydantic.main.BaseModel.__setattr__()

ValueError: "ESMCatalogModel" object has no field "df"
```

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
