### PR TITLE
Derived Catalog: test for all needed variables and skip if existing

### DIFF
--- a/intake_esm/derived.py
+++ b/intake_esm/derived.py
@@ -182,8 +182,11 @@ class DerivedVariableRegistry:
 
         for dset_key, dataset in datasets.items():
             for _, derived_variable in self.items():
-                if set(dataset.variables).intersection(
-                    derived_variable.dependent_variables(variable_key_name)
+                if (
+                    set(dataset.variables).issuperset(
+                        derived_variable.dependent_variables(variable_key_name)
+                    )
+                    and derived_variable.variable not in dataset.variables
                 ):
                     try:
                         # Assumes all dependent variables are in the same dataset

--- a/intake_esm/derived.py
+++ b/intake_esm/derived.py
@@ -15,6 +15,7 @@ class DerivedVariable(pydantic.BaseModel):
     func: typing.Callable
     variable: pydantic.StrictStr
     query: typing.Dict[pydantic.StrictStr, typing.Union[typing.Any, typing.List[typing.Any]]]
+    prefer_derived: bool
 
     @pydantic.validator('query')
     def validate_query(cls, values):
@@ -92,6 +93,7 @@ class DerivedVariableRegistry:
         *,
         variable: str,
         query: typing.Dict[pydantic.StrictStr, typing.Union[typing.Any, typing.List[typing.Any]]],
+        prefer_derived: bool = False,
     ) -> typing.Callable:
         """Register a derived variable
 
@@ -103,13 +105,18 @@ class DerivedVariableRegistry:
             The name of the variable to derive.
         query : typing.Dict[str, typing.Union[typing.Any, typing.List[typing.Any]]]
             The query to use to retrieve dependent variables required to derive `variable`.
+        prefer_derived: bool, optional (default=False)
+            Specify whether to compute this variable on datasets that already contain a variable
+            of the same name. Default (False) is to leave the existing variable.
 
         Returns
         -------
         typing.Callable
             The function that was registered.
         """
-        self._registry[variable] = DerivedVariable(func=func, variable=variable, query=query)
+        self._registry[variable] = DerivedVariable(
+            func=func, variable=variable, query=query, prefer_derived=prefer_derived
+        )
         return func
 
     def __contains__(self, item: str) -> bool:
@@ -182,11 +189,11 @@ class DerivedVariableRegistry:
 
         for dset_key, dataset in datasets.items():
             for _, derived_variable in self.items():
-                if (
-                    set(dataset.variables).issuperset(
-                        derived_variable.dependent_variables(variable_key_name)
-                    )
-                    and derived_variable.variable not in dataset.variables
+                if set(dataset.variables).issuperset(
+                    derived_variable.dependent_variables(variable_key_name)
+                ) and (
+                    (derived_variable.variable not in dataset.variables)
+                    or derived_variable.prefer_derived
                 ):
                     try:
                         # Assumes all dependent variables are in the same dataset

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -128,3 +128,17 @@ def test_registry_derive_variables_error():
     )
     assert {'air', 'FOO'} == dsets['test'].data_vars.keys()
     assert ds.air.equals(dsets['test'].FOO)
+
+    @dvr.register(variable='FOO', query={'variable': ['air']}, prefer_derived=True)
+    def funce(ds):
+        ds['FOO'] = ds.air * 2
+        return ds
+
+    # No error, FOO is recomputed
+    dsets = dvr.update_datasets(
+        datasets={'test': ds.assign(FOO=ds.air).copy()},
+        variable_key_name='variable',
+        skip_on_error=False,
+    )
+    assert {'air', 'FOO'} == dsets['test'].data_vars.keys()
+    assert ds.air.equals(dsets['test'].FOO / 2)


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

When updating datasets with derived variable calculations, the current code calls the derived variable as soon as at least one dependency is present in the dataset. It also overwrites variables if they are already present.

This PR ensures that _all_ dependencies are present before computing the derived cat. What would have resulted in an error before now is silently skipped.

This PR also skips the calculation if a variable of the same name already exists. The use case here is when a variable is missing on some datasets but not others. For example "tas", it's better to use a native "tas" than one derived from "tasmin" and "tasmax". 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
