### PR TITLE
Subset derived variable registry only with used derived variables

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,11 @@ def funcs(ds):
     return ds + 1
 
 
+@registry.register(variable='FLNS', query={'variable': ['FOO', 'FLUT']})
+def func2(ds):
+    return ds - 1
+
+
 registry_multivar = intake_esm.DerivedVariableRegistry()
 
 
@@ -138,7 +143,7 @@ def test_catalog_with_registry_search():
     assert len(cat) == 56
     assert len(new_cat) == 11
 
-    assert len(cat.derivedcat) == 2
+    assert len(cat.derivedcat) == 3
     assert len(new_cat.derivedcat) == 1
 
     new_cat = cat.search(variable='FOO', frequency='daily')
@@ -146,7 +151,7 @@ def test_catalog_with_registry_search():
     assert len(new_cat.derivedcat) == 1
 
     new_cat = cat.search(frequency='daily')
-    assert len(new_cat.derivedcat) == 2
+    assert len(new_cat.derivedcat) == 3
 
 
 @pytest.mark.parametrize('key', ['ocn.20C.pop.h', 'ocn.CTRL.pop.h', 'ocn.RCP85.pop.h'])


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->
When searching for variables, the subset of the derived variable registry is constructed from the dependent variables that returned results when their query was searched.

This mainly changes two things:
- If a derived variable has a dependent that also exists as a derived variable in the DVR, that second dv is nonetheless not included in the subset. Fixing #445.
- If a requested variable corresponds to a derived variable but none of the dependents were found in the catalog, that derived variable is not included in the subset.  I don't think this is a breaking change. That behaviour was not causing problems on my side, but I do think it's a bit cleaner this way?

## Related issue number
Fixes #445.

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
