### PR TITLE
Support for the grid mapping attribute and variable

### DIFF
--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -73,6 +73,7 @@ def _open_dataset(
             requested_variables = [requested_variables]
         variable_intersection = set(requested_variables).intersection(set(varname))
         variables = [variable for variable in variable_intersection if variable in ds.data_vars]
+        variables.extend([ds[v].attrs["grid_mapping"] for v in variables if "grid_mapping" in ds[v].attrs])
         ds = ds[variables]
         ds.attrs[INTAKE_ESM_VARS_KEY] = variables
     else:

--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -73,7 +73,7 @@ def _open_dataset(
             requested_variables = [requested_variables]
         variable_intersection = set(requested_variables).intersection(set(varname))
         variables = [variable for variable in variable_intersection if variable in ds.data_vars]
-        variables.extend([ds[v].attrs["grid_mapping"] for v in variables if "grid_mapping" in ds[v].attrs])
+        variables.extend(set([ds[v].attrs["grid_mapping"] for v in variables if "grid_mapping" in ds[v].attrs]))
         ds = ds[variables]
         ds.attrs[INTAKE_ESM_VARS_KEY] = variables
     else:

--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -73,7 +73,8 @@ def _open_dataset(
             requested_variables = [requested_variables]
         variable_intersection = set(requested_variables).intersection(set(varname))
         variables = [variable for variable in variable_intersection if variable in ds.data_vars]
-        variables.extend(set([ds[v].attrs["grid_mapping"] for v in variables if "grid_mapping" in ds[v].attrs]))
+        scalar_variables = [v for v in ds.data_vars if len(ds[v].dims) == 0]
+        ds = ds.set_coords(scalar_variables)
         ds = ds[variables]
         ds.attrs[INTAKE_ESM_VARS_KEY] = variables
     else:


### PR DESCRIPTION
The `grid_mapping` attribute is used in CF Conventions to link a variable to its grid properties in the case of non-regular grids. These grids are very common for regional climate models. However, the current behaviour of `_open_dataset()` drops the grid_mapping variable (e.g. `rotated_pole`), since it is not recognized as a `requested_variables`

This small modification searches for the `grid_mapping` attribute within the `requested_variables` and if found, adds the related variable to the output.