### PR TITLE
Change import to have configurable prefixes via `set_options`

### DIFF
--- a/docs/source/reference/api.md
+++ b/docs/source/reference/api.md
@@ -50,3 +50,10 @@ For more details and examples, refer to the relevant chapters in the main part o
     :noindex:
     :special-members: __init__
 ```
+
+## Options for dataset attributes
+
+```{eval-rst}
+.. autoclass:: intake_esm.utils.set_options
+    :noindex:
+```

--- a/intake_esm/__init__.py
+++ b/intake_esm/__init__.py
@@ -8,7 +8,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 from . import tutorial
 from .core import esm_datastore
 from .derived import DerivedVariableRegistry, default_registry
-from .utils import show_versions
+from .utils import set_options, show_versions
 
 try:
     __version__ = get_distribution(__name__).version

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -475,6 +475,10 @@ class esm_datastore(Catalog):
         """
         Load catalog entries into a dictionary of xarray datasets.
 
+        Column values, dataset keys and requested variables are added as global
+        attributes on the returned datasets. The names of these attributes can be
+        customized with :py:class:`intake_esm.utils.set_options`.
+
         Parameters
         ----------
         xarray_open_kwargs : dict

--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -7,8 +7,8 @@ import pydantic
 import xarray as xr
 from intake.source.base import DataSource, Schema
 
-from . import utils as u
 from .cat import Aggregation, DataFormat
+from .utils import OPTIONS
 
 
 class ESMDataSourceError(Exception):
@@ -74,9 +74,9 @@ def _open_dataset(
         variable_intersection = set(requested_variables).intersection(set(varname))
         variables = [variable for variable in variable_intersection if variable in ds.data_vars]
         ds = ds[variables]
-        ds.attrs[u.INTAKE_ESM_VARS_KEY] = variables
+        ds.attrs[OPTIONS['vars_key']] = variables
     else:
-        ds.attrs[u.INTAKE_ESM_VARS_KEY] = varname
+        ds.attrs[OPTIONS['vars_key']] = varname
 
     ds = _expand_dims(expand_dims, ds)
     ds = _update_attrs(additional_attrs, ds)
@@ -87,7 +87,7 @@ def _update_attrs(additional_attrs, ds):
     additional_attrs = additional_attrs or {}
     if additional_attrs:
         additional_attrs = {
-            f'{u.INTAKE_ESM_ATTRS_PREFIX}/{key}': value for key, value in additional_attrs.items()
+            f"{OPTIONS['attrs_prefix']}/{key}": value for key, value in additional_attrs.items()
         }
     ds.attrs = {**ds.attrs, **additional_attrs}
     return ds
@@ -95,7 +95,7 @@ def _update_attrs(additional_attrs, ds):
 
 def _expand_dims(expand_dims, ds):
     if expand_dims:
-        for variable in ds.attrs[u.INTAKE_ESM_VARS_KEY]:
+        for variable in ds.attrs[OPTIONS['vars_key']]:
             ds[variable] = ds[variable].expand_dims(**expand_dims)
 
     return ds
@@ -230,7 +230,7 @@ class ESMDataSource(DataSource):
                 datasets = sorted(
                     datasets,
                     key=lambda ds: tuple(
-                        f'{u.INTAKE_ESM_ATTRS_PREFIX}/{agg.attribute_name}'
+                        f"{OPTIONS['attrs_prefix']}/{agg.attribute_name}"
                         for agg in self.aggregations
                     ),
                 )
@@ -238,14 +238,14 @@ class ESMDataSource(DataSource):
                     {'scheduler': 'single-threaded', 'array.slicing.split_large_chunks': True}
                 ):  # Use single-threaded scheduler
                     datasets = [
-                        ds.set_coords(set(ds.variables) - set(ds.attrs[u.INTAKE_ESM_VARS_KEY]))
+                        ds.set_coords(set(ds.variables) - set(ds.attrs[OPTIONS['vars_key']]))
                         for ds in datasets
                     ]
                     self._ds = xr.combine_by_coords(
                         datasets, **self.xarray_combine_by_coords_kwargs
                     )
 
-            self._ds.attrs[u.INTAKE_ESM_DATASET_KEY] = self.key
+            self._ds.attrs[OPTIONS['dataset_key']] = self.key
 
         except Exception as exc:
             raise ESMDataSourceError(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -468,7 +468,7 @@ def test_subclassing():
     intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX = 'mychild'
 
     _, ds = scat.to_dataset_dict(
-        xarray_open_kwargs={'backend_kwargsd': {'storage_options': {'anon': True}}},
+        xarray_open_kwargs={'backend_kwargs': {'storage_options': {'anon': True}}},
     ).popitem()
     assert ds.attrs['mychild/component'] == 'atm'
     intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX = old

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -467,6 +467,8 @@ def test_subclassing():
     old = intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX[:]
     intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX = 'mychild'
 
-    _, ds = scat.to_dataset_dict().popitem()
+    _, ds = scat.to_dataset_dict(
+        xarray_open_kwargs={'backend_kwargsd': {'storage_options': {'anon': True}}},
+    ).popitem()
     assert ds.attrs['mychild/component'] == 'atm'
     intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX = old

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -456,10 +456,17 @@ def test_to_dataset_dict_with_registry():
         )
 
 
-def test_subclassing_catalog():
+def test_subclassing():
     class ChildCatalog(intake_esm.esm_datastore):
         pass
 
     cat = ChildCatalog(catalog_dict_records)
-    scat = cat.search(variable=['FOO', 'BAR'])
+    scat = cat.search(variable=['FLNS'])
     assert type(scat) is ChildCatalog
+
+    old = intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX[:]
+    intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX = 'mychild'
+
+    _, ds = scat.to_dataset_dict().popitem()
+    assert ds.attrs['mychild/component'] == 'atm'
+    intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX = old

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -456,7 +456,7 @@ def test_to_dataset_dict_with_registry():
         )
 
 
-def test_subclassing():
+def test_subclassing_catalog():
     class ChildCatalog(intake_esm.esm_datastore):
         pass
 
@@ -464,11 +464,12 @@ def test_subclassing():
     scat = cat.search(variable=['FLNS'])
     assert type(scat) is ChildCatalog
 
-    old = intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX[:]
-    intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX = 'mychild'
 
-    _, ds = scat.to_dataset_dict(
-        xarray_open_kwargs={'backend_kwargs': {'storage_options': {'anon': True}}},
-    ).popitem()
-    assert ds.attrs['mychild/component'] == 'atm'
-    intake_esm.utils.INTAKE_ESM_ATTRS_PREFIX = old
+def test_options():
+    cat = intake.open_esm_datastore(catalog_dict_records)
+    scat = cat.search(variable=['FLNS'])
+    with intake_esm.set_options(attrs_prefix='myprefix'):
+        _, ds = scat.to_dataset_dict(
+            xarray_open_kwargs={'backend_kwargs': {'storage_options': {'anon': True}}},
+        ).popitem()
+        assert ds.attrs['myprefix/component'] == 'atm'


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary
Restructures the import of the default attribute names and prefixes in `source.py` so that they are actually configurable by patching the variables in `utils.py`.

## Related issue number
No issue sorry.

The problem was the `source.py` _imported_ the variables directly, this **copying** the python reference to the string. As strings  are non-mutable, someone that would want to customize the attribute names has to re-set the variable in the `utils` module (I think this is called "monkey-patching" ?). But that doesn't update the version in `source.py`. Here, the solution is to import the whole `utils` module object in `source`, so that the strings are queried as members of the module everytime they are needed, not only a import time.
## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
