### PR TITLE
ensure `storage_options` are passed to data loader

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -557,6 +557,7 @@ class esm_datastore(Catalog):
             )
 
         xarray_open_kwargs = xarray_open_kwargs or {}
+
         xarray_combine_by_coords_kwargs = xarray_combine_by_coords_kwargs or {}
         cdf_kwargs, zarr_kwargs = kwargs.get('cdf_kwargs'), kwargs.get('zarr_kwargs')
 
@@ -577,6 +578,7 @@ class esm_datastore(Catalog):
             xarray_combine_by_coords_kwargs=xarray_combine_by_coords_kwargs,
             preprocess=preprocess,
             requested_variables=self._requested_variables,
+            storage_options=storage_options,
         )
 
         if aggregate is not None and not aggregate:


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

@mgrover1, this PR should fix the issue you ran into with `storage_options`

```python
In [1]: import intake

In [2]: catalog = intake.open_esm_datastore(
   ...:     'https://raw.githubusercontent.com/NCAR/cesm2-le-aws/main/intake-catalogs/aws-cesm2-le.json'
   ...: )
   ...: catalog
Out[2]: <IPython.core.display.HTML object>

In [3]: catalog_subset = catalog.search(variable='TREFHT', frequency='daily')
   ...: catalog_subset
Out[3]: <IPython.core.display.HTML object>

In [4]: dsets = catalog_subset.to_dataset_dict(storage_options={'anon':True})

--> The keys in the returned dictionary of datasets are constructed as follows:
        'component.experiment.frequency.forcing_variant'
 |████████████████████████████████████████████████████████████████████████████████████████| 100.00% [4/4 00:01<00:00]
In [5]: 
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

- Fixes #506

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
