### PR TITLE
Discard `catalog_file` attribute after a search

### DIFF
--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -2,7 +2,6 @@ import datetime
 import enum
 import json
 import os
-import pathlib
 import typing
 
 import fsspec
@@ -164,9 +163,7 @@ class ESMCatalogModel(pydantic.BaseModel):
             raise ValueError(
                 f'catalog_type must be either "dict" or "file". Received catalog_type={catalog_type}'
             )
-        if isinstance(directory, pathlib.Path):
-            directory = str(directory)
-        mapper = fsspec.get_mapper(directory or '.', storage_options=storage_options)
+        mapper = fsspec.get_mapper(f'{directory}' or '.', storage_options=storage_options)
         fs = mapper.fs
         csv_file_name = f'{mapper.fs.protocol}://{mapper.root}/{name}.csv'
         json_file_name = f'{mapper.fs.protocol}://{mapper.root}/{name}.json'

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -364,6 +364,7 @@ class esm_datastore(Catalog):
             )
 
         cat = self.__class__({'esmcat': self.esmcat.dict(), 'df': esmcat_results})
+        cat.esmcat.catalog_file = None  # Don't save the catalog file
         if self.esmcat.has_multiple_variable_assets:
             requested_variables = list(set(variables or []).union(dependents))
         else:


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

This PR ensures the `.esmcat.catalog_file` attribute is set to `None` after a search. 

```python

In [1]: import intake

In [2]: cat = intake.open_esm_datastore("./tests/sample-catalogs/cesm1-lens-netcdf.json")

In [3]: cat.esmcat.catalog_file
Out[3]: '/home/andersy005/devel/intake/intake-esm/./tests/sample-catalogs/cesm1-lens-netcdf.csv'

In [4]: cat.search().esmcat.catalog_file
```



## Related issue number

- Closes #447 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
