### PR TITLE
Add `keys_info()` method

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -134,6 +134,19 @@ class esm_datastore(Catalog):
         pandas.DataFrame
             keys for the catalog entries and their metadata
 
+        Examples
+        --------
+
+        >>> import intake
+        >>> cat = intake.open_esm_datastore("./tests/sample-catalogs/cesm1-lens-netcdf.json")
+        >>> cat.keys_info()
+                        component experiment stream
+        key
+        ocn.20C.pop.h         ocn        20C  pop.h
+        ocn.CTRL.pop.h        ocn       CTRL  pop.h
+        ocn.RCP85.pop.h       ocn      RCP85  pop.h
+
+
 
         """
         results = self.esmcat._construct_group_keys(sep=self.sep)

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -125,6 +125,26 @@ class esm_datastore(Catalog):
         """
         return list(self.esmcat._construct_group_keys(sep=self.sep).keys())
 
+    def keys_info(self) -> pd.DataFrame:
+        """
+        Get keys for the catalog entries and their metadata
+
+        Returns
+        -------
+        pandas.DataFrame
+            keys for the catalog entries and their metadata
+
+
+        """
+        results = self.esmcat._construct_group_keys(sep=self.sep)
+        data = {
+            key: dict(zip(self.esmcat.aggregation_control.groupby_attrs, results[key]))
+            for key in results
+        }
+        data = pd.DataFrame.from_dict(data, orient='index')
+        data.index.name = 'key'
+        return data
+
     @property
     def key_template(self) -> str:
         """
@@ -258,6 +278,7 @@ class esm_datastore(Catalog):
             'to_datatree',
             'to_dask',
             'keys',
+            'keys_info',
             'serialize',
             'datasets',
             'search',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -167,6 +167,14 @@ def test_catalog_getitem_error():
         cat['foo']
 
 
+def test_catalog_keys_info():
+    cat = intake.open_esm_datastore(cdf_cat_sample_cesmle)
+    data = cat.keys_info()
+    assert isinstance(data, pd.DataFrame)
+    assert data.index.name == 'key'
+    assert len(data) == len(cat)
+
+
 @pytest.mark.parametrize(
     'catalog_type, to_csv_kwargs, json_dump_kwargs',
     [('file', {'compression': 'bz2'}, {}), ('file', {'compression': 'gzip'}, {}), ('dict', {}, {})],


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

This PR adds a `.keys_info()` method as requested by @matt-long in #461. It returns a dataframe in which the keys are index and the columns are the groupby  attributes. 



```python
In [1]: import intake

In [2]: cat = intake.open_esm_datastore("./tests/sample-catalogs/cesm1-lens-netcdf.json")

In [3]: cat.keys_info()
Out[3]: 
                component experiment stream
key                                        
ocn.20C.pop.h         ocn        20C  pop.h
ocn.CTRL.pop.h        ocn       CTRL  pop.h
ocn.RCP85.pop.h       ocn      RCP85  pop.h
```
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

- Closes #461

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
