### PR TITLE
Update isort configuration to use `profile=black`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,13 +6,7 @@ max-complexity = 18
 select = B,C,E,F,W,T4,B9
 
 [isort]
-known_first_party=intake_esm
-known_third_party=dask,fastprogress,fsspec,intake,numpy,pandas,pkg_resources,pydantic,pytest,requests,setuptools,tlz,xarray,yaml
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-combine_as_imports=True
-line_length=100
+profile = black
 skip=
     docs/source/conf.py
     setup.py

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -3,7 +3,11 @@ import sys
 import pytest
 import xarray as xr
 
-from intake_esm.derived import DerivedVariable, DerivedVariableError, DerivedVariableRegistry
+from intake_esm.derived import (
+    DerivedVariable,
+    DerivedVariableError,
+    DerivedVariableRegistry,
+)
 
 from .utils import here
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
