### PR TITLE
FIX: Add dask config single-threaded to build catalog from timeseries

### DIFF
--- a/docs/source/how-to/build-a-catalog-from-timeseries-files.md
+++ b/docs/source/how-to/build-a-catalog-from-timeseries-files.md
@@ -57,9 +57,12 @@ The only parts of ecgtools we need are the `Builder` object and the `parse_cesm_
 ```{code-cell} ipython3
 import pathlib
 
+import dask
 import intake
 from ecgtools import Builder
 from ecgtools.parsers.cesm import parse_cesm_timeseries
+
+dask.config.set(scheduler='single-threaded')
 ```
 
 ## Understanding the directory structure

--- a/docs/source/how-to/build-a-catalog-from-timeseries-files.md
+++ b/docs/source/how-to/build-a-catalog-from-timeseries-files.md
@@ -93,7 +93,7 @@ cat_builder = Builder(
     # Exclude the timeseries and restart directories
     exclude_patterns=["*/tseries/*", "*/rest/*"],
     # Number of jobs to execute - should be equal to # threads you are using
-    joblib_parallel_kwargs={'n_jobs': 5},
+    joblib_parallel_kwargs={'n_jobs': -1},
 )
 
 cat_builder


### PR DESCRIPTION
## Change Summary

Fix the failing docs issue by ensuring single threaded with build catalog from timeseries how to 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable
