### PR TITLE
Pin minimum versions for fsspec, gcsfs, and s3fs

### DIFF
--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -6,8 +6,8 @@ dependencies:
   - cftime
   - distributed
   - ecgtools >=2022.10.7
-  - fsspec>=2022.7.0
-  - gcsfs
+  - fsspec>=2022.11.0
+  - gcsfs >=2022.11.0
   - intake>=0.6.6
   - jupyterlab
   - matplotlib
@@ -16,7 +16,7 @@ dependencies:
   - pydantic>=1.9
   - python-graphviz
   - python=3.10
-  - s3fs >=2022.8.2
+  - s3fs >=2022.11.0
   - sphinx
   - sphinx-copybutton
   - sphinx-design

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - codecov
   - dask>=2022.02.0
   - fastprogress>=1.0.0
-  - gcsfs
+  - gcsfs >=2022.11.0
   - h5netcdf>=0.8.1
   - ipython
   - matplotlib
@@ -27,7 +27,7 @@ dependencies:
   - pytest-sugar
   - pytest-xdist
   - regionmask
-  - s3fs
+  - s3fs >=2022.11.0
   - scipy
   - xarray-datatree
   - xgcm

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,8 +6,8 @@ dependencies:
   - cftime
   - codecov
   - fastprogress>=1.0.0
-  - fsspec>=2022.7.0
-  - gcsfs
+  - fsspec>=2022.11.0
+  - gcsfs >=2022.11.0
   - h5netcdf>=0.8.1
   - intake>=0.6.6
   - ipython
@@ -22,7 +22,7 @@ dependencies:
   - pytest-sugar
   - pytest-xdist
   - pytest-mock
-  - s3fs >=2022.8.2
+  - s3fs >=2022.11.0
   - scipy
   - xarray>=2022.06
   - xarray-datatree

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dask[complete]>=2022.02.0
 fastprogress>=1.0.0
-fsspec>=2022.7.0
+fsspec>=2022.11.0
 intake>=0.6.6
 netCDF4>=1.5.5
 requests>=2.24.0


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

This is an attempt at fixing CI failures related to versions mismatches. see https://github.com/intake/intake-esm/actions/runs/3991956830/jobs/6847327740

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
