### PR TITLE
Add support for None NaN NA is search query - add tests

### DIFF
--- a/intake_esm/_search.py
+++ b/intake_esm/_search.py
@@ -48,6 +48,8 @@ def search(
                 mask = df[column].str.contains(value, regex=False)
             elif column_is_stringtype and is_pattern(value):
                 mask = df[column].str.contains(value, regex=True, case=True, flags=0)
+            elif pd.isna(value):
+                mask = df[column].isnull()
             else:
                 mask = df[column] == value
             local_mask = local_mask | mask

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -441,7 +441,7 @@ class QueryModel(pydantic.BaseModel):
                     raise ValueError(f'Column {key} not in columns {columns}')
         _query = query.copy()
         for key, value in _query.items():
-            if isinstance(value, (str, int, float, bool)):
+            if isinstance(value, (str, int, float, bool)) or value is None or value is pd.NA:
                 _query[key] = [value]
 
         values['query'] = _query

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -121,7 +121,7 @@ def test_esmcatmodel_unique_and_nunique(query, expected_unique_vals, expected_nu
 
 @pytest.mark.parametrize(
     'query, columns, require_all_on',
-    [({'foo': 1}, ['foo', 'bar'], ['bar']), ({'bar': 1}, ['foo', 'bar'], 'foo')],
+    [({'foo': 1}, ['foo', 'bar'], ['bar']), ({'bar': 1}, ['foo', 'bar'], 'foo'), ({'foo': None}, ['foo', 'bar'], None)],
 )
 def test_query_model(query, columns, require_all_on):
     q = QueryModel(query=query, columns=columns, require_all_on=require_all_on)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,5 @@
 import re
-
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -116,6 +116,16 @@ params = [
             {'A': 'NASA', 'B': 'foo', 'C': 'HiSt', 'D': 'tAs'},
         ],
     ),
+    (
+        {'A': None},
+        None,
+        [{'A': None, 'B': None, 'C': 'exp', 'D': 'UA'}]
+    ),
+    (
+        {'A': np.nan},
+        None,
+        [{'A': None, 'B': None, 'C': 'exp', 'D': 'UA'}]
+    )
 ]
 
 
@@ -123,10 +133,10 @@ params = [
 def test_search(query, require_all_on, expected):
     df = pd.DataFrame(
         {
-            'A': ['NCAR', 'IPSL', 'IPSL', 'CSIRO', 'IPSL', 'NCAR', 'NOAA', 'NCAR', 'NASA'],
-            'B': ['CESM', 'FOO', 'FOO', 'BAR', 'FOO', 'CESM', 'GCM', 'WACM', 'foo'],
-            'C': ['hist', 'control', 'hist', 'control', 'hist', 'control', 'hist', 'hist', 'HiSt'],
-            'D': ['O2', 'O2', 'O2', 'O2', 'NO2', 'O2', 'O2', 'TA', 'tAs'],
+            'A': ['NCAR', 'IPSL', 'IPSL', 'CSIRO', 'IPSL', 'NCAR', 'NOAA', 'NCAR', 'NASA', None],
+            'B': ['CESM', 'FOO', 'FOO', 'BAR', 'FOO', 'CESM', 'GCM', 'WACM', 'foo', None],
+            'C': ['hist', 'control', 'hist', 'control', 'hist', 'control', 'hist', 'hist', 'HiSt', 'exp'],
+            'D': ['O2', 'O2', 'O2', 'O2', 'NO2', 'O2', 'O2', 'TA', 'tAs', 'UA'],
         }
     )
     query_model = QueryModel(


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->
`_search.search` will use `df[column].isnull()` if `column=None` has been passed. `np.NaN` and `pd.NA` or anything that `pd.isna(value)` is suported.

## Related issue number
Fixes #611.
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
There are two added `search` tests because the case `None` was raising an error is `QueryModel`, while `np.nan` (which is a float) was not.