### PR TITLE
Remove hardcoded single-threaded dask scheduler for dataset combine

### DIFF
--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -252,16 +252,13 @@ class ESMDataSource(DataSource):
                         for agg in self.aggregations
                     ),
                 )
-                with dask.config.set(
-                    {'scheduler': 'single-threaded', 'array.slicing.split_large_chunks': True}
-                ):  # Use single-threaded scheduler
-                    datasets = [
-                        ds.set_coords(set(ds.variables) - set(ds.attrs[OPTIONS['vars_key']]))
-                        for ds in datasets
-                    ]
-                    self._ds = xr.combine_by_coords(
-                        datasets, **self.xarray_combine_by_coords_kwargs
-                    )
+                datasets = [
+                    ds.set_coords(set(ds.variables) - set(ds.attrs[OPTIONS['vars_key']]))
+                    for ds in datasets
+                ]
+                self._ds = xr.combine_by_coords(
+                    datasets, **self.xarray_combine_by_coords_kwargs
+                )
 
             self._ds.attrs[OPTIONS['dataset_key']] = self.key
 

--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -256,9 +256,7 @@ class ESMDataSource(DataSource):
                     ds.set_coords(set(ds.variables) - set(ds.attrs[OPTIONS['vars_key']]))
                     for ds in datasets
                 ]
-                self._ds = xr.combine_by_coords(
-                    datasets, **self.xarray_combine_by_coords_kwargs
-                )
+                self._ds = xr.combine_by_coords(datasets, **self.xarray_combine_by_coords_kwargs)
 
             self._ds.attrs[OPTIONS['dataset_key']] = self.key
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

With this PR, dataset combine is no longer hardcoded to use a single-threaded dask scheduler. Hardcoding this, leads to regular UserWarnings as many/most users already have an active distributed client. I'm happy to be told that this is a bad idea, or that there's a better way to fix the issue reported in #596, but I'm submitting this now to get the ball rolling.

## Related issue number

Closes #596 

## Checklist

- [x] Unit tests for the changes exist (not really appropriate here)
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
