### PR TITLE
ADD: Add levels option to to_datatree()

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -697,6 +697,7 @@ class esm_datastore(Catalog):
         progressbar: typing.Optional[pydantic.StrictBool] = None,
         aggregate: typing.Optional[pydantic.StrictBool] = None,
         skip_on_error: pydantic.StrictBool = False,
+        levels: list[str] = None,
         **kwargs,
     ):
         """
@@ -720,6 +721,9 @@ class esm_datastore(Catalog):
             If False, no aggregation will be done.
         skip_on_error : bool, optional
             If True, skip datasets that cannot be loaded and/or variables we are unable to derive.
+        levels : list[str], optional
+            List of fields to use as the datatree nodes. WARNING: This will overwrite the fields
+            used to create the unique aggregation keys.
 
         Returns
         -------
@@ -760,6 +764,11 @@ class esm_datastore(Catalog):
                 'To proceed please install xarray-datatree using: '
                 ' `python -m pip install xarray-datatree` or `conda install -c conda-forge xarray-datatree`.'
             )
+
+        # Change the groupby controls if neccessary, used to assemble the tree
+        if levels is not None:
+            self = deepcopy(self)
+            self.esmcat.aggregation_control.groupby_attrs = levels
 
         # Set the separator to a / for datatree temporarily
         self.sep, old_sep = '/', self.sep

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -411,9 +411,9 @@ def test_to_datatree_levels():
             'consolidated': True,
             'backend_kwargs': {'storage_options': {'token': 'anon'}},
         },
-        levels=['activity_id', 'institution_id', 'source_id'],
+        levels=['source_id'],
     )
-    assert tree.keys() == ['activity_id', 'institution_id', 'source_id']
+    assert list(tree.keys()) == ['BCC-ESM1']
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -393,6 +393,29 @@ def test_to_datatree(path, query, xarray_open_kwargs):
     assert isinstance(tree, DataTree)
 
 
+def test_to_datatree_levels():
+    cat = intake.open_esm_datastore(zarr_cat_pangeo_cmip6)
+    cat_sub = cat.search(
+        **dict(
+            variable_id=['pr'],
+            experiment_id='ssp370',
+            activity_id='AerChemMIP',
+            source_id='BCC-ESM1',
+            table_id='Amon',
+            grid_label='gn',
+        ),
+    )
+
+    tree = cat_sub.to_datatree(
+        xarray_open_kwargs={
+            'consolidated': True,
+            'backend_kwargs': {'storage_options': {'token': 'anon'}},
+        },
+        levels=['activity_id', 'institution_id', 'source_id'],
+    )
+    assert tree.keys() == ['activity_id', 'institution_id', 'source_id']
+
+
 @pytest.mark.parametrize(
     'path, query, xarray_open_kwargs',
     [


### PR DESCRIPTION
## Change Summary

Add `levels` as an argument to `.to_datatree()`
## Related issue number

Closes #562 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable
