### PR TITLE
Use `chunks="auto"` by default in `xarray_open_kwargs`

### DIFF
--- a/intake_esm/source.py
+++ b/intake_esm/source.py
@@ -19,7 +19,7 @@ def _get_xarray_open_kwargs(data_format, xarray_open_kwargs=None, storage_option
     xarray_open_kwargs = (xarray_open_kwargs or {}).copy()
     _default_open_kwargs = {
         'engine': 'zarr' if data_format in {'zarr', 'reference'} else 'netcdf4',
-        'chunks': {},
+        'chunks': 'auto',
         'backend_kwargs': {},
     }
     xarray_open_kwargs = (


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Very small change to default to `chunks="auto"` rather than `chunks={}` when opening files with xarray. This is motivated by [recent changes in xarray](https://docs.xarray.dev/en/stable/whats-new.html#v2023-09-0-sep-26-2023) to the behaviour of `chunks={}`.

## Related issue number

Closes #632 

## Checklist

- [ ] Tests pass on CI

<!--
Please add any other relevant info below:
-->
