### PR TITLE
ADD: Add ci support for python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -12,7 +12,7 @@ dependencies:
   - h5netcdf>=0.8.1
   - ipython
   - matplotlib
-  - netcdf4>=1.5.5,<1.6.1
+  - netcdf4>=1.5.5
   - pandas
   - pip
   - pooch

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - intake>=0.6.6
   - ipython
   - matplotlib
-  - netcdf4>=1.5.5,<1.6.1
+  - netcdf4>=1.5.5
   - pip
   - pooch
   - pre-commit


### PR DESCRIPTION
## Change Summary

Add continuous integration tests for python 3.12.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable
