### PR TITLE
Fix for fsspec 2023.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Bugs fixed
+
+- Fix catalog serialization with fsspec 2023.10.0 [#636](https://github.com/intake/intake-esm/pull/636) ([@aulemahal](https://github.com/aulemahal))
+
+## v2023.07.07
+
 ### New features added
 
 - Fix the link to documentation build status [#591](https://github.com/intake/intake-esm/pull/591) ([@mgrover1](https://github.com/mgrover1))

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -182,8 +182,8 @@ class ESMCatalogModel(pydantic.BaseModel):
         # Configure the fsspec mapper and associated filenames
         mapper = fsspec.get_mapper(f'{directory}', storage_options=storage_options)
         fs = mapper.fs
-        csv_file_name = f'{mapper.fs.protocol}://{mapper.root}/{name}.csv'
-        json_file_name = f'{mapper.fs.protocol}://{mapper.root}/{name}.json'
+        csv_file_name = fs.unstrip_protocol(f'{mapper.root}/{name}.csv')
+        json_file_name = fs.unstrip_protocol(f'{mapper.root}/{name}.json')
 
         data = self.dict().copy()
         for key in {'catalog_dict', 'catalog_file'}:


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->
Instead of a custom f-string to get the full path of files, I used a method of the filesystem object. This solves the string vs tuple issue.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #635.
## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
I did not test with serialization to anything else than a local filesystem.

I tested with fsspec 2022.11.0, the lower bound supported by `intake-esm`, and the MWE in the issue works as expected.