### PR TITLE
Replace applymap with map

### DIFF
--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -13,6 +13,7 @@ dependencies:
   - matplotlib
   - myst-nb
   - netcdf4!=1.6.1
+  - pandas>=2.1.0
   - pip
   - pydantic>=2.0
   - python-graphviz

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - ipython
   - matplotlib
   - netcdf4>=1.5.5,<1.6.1
-  - pandas
+  - pandas>=2.1.0
   - pip
   - pooch
   - pre-commit

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - ipython
   - matplotlib
   - netcdf4>=1.5.5,<1.6.1
+  - pandas>=2.1.0
   - pip
   - pooch
   - pre-commit

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -267,7 +267,7 @@ class ESMCatalogModel(pydantic.BaseModel):
             return set()
         has_iterables = (
             self._df.sample(20, replace=True)
-            .applymap(type)
+            .map(type)
             .isin([list, tuple, set])
             .any()
             .to_dict()

--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -266,11 +266,7 @@ class ESMCatalogModel(pydantic.BaseModel):
         if self._df.empty:
             return set()
         has_iterables = (
-            self._df.sample(20, replace=True)
-            .map(type)
-            .isin([list, tuple, set])
-            .any()
-            .to_dict()
+            self._df.sample(20, replace=True).map(type).isin([list, tuple, set]).any().to_dict()
         )
         return {column for column, check in has_iterables.items() if check}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastprogress>=1.0.0
 fsspec>=2022.11.0
 intake>=0.6.6
 netCDF4>=1.5.5
+pandas>=2.1.0
 requests>=2.24.0
 xarray>=2022.06
 zarr>=2.12


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Very small change to replace deprecated pandas `df.applymap` method with `df.map`. The `map` method was added in pandas 2.1.0, so this min version is added to the requirements and ci environments. I guess this min version should also be added to the [conda-forge feedstock recipe](https://github.com/conda-forge/intake-esm-feedstock/blob/main/recipe/meta.yaml), but I'll leave that to one of the maintainers.

## Related issue number

Closes #629 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
