### PR TITLE
Update CONTRIBUTING guidelines to e.g. refer to new default branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ $ make docs
    $ python -m pip install -e .
    ```
 
-5. Install `pre-commit <https://pre-commit.com>`\_ hooks on the intake-esm repo::
+5. Install [pre-commit](https://pre-commit.com) hooks on the intake-esm repo::
 
    ```bash
    $ pre-commit install
@@ -110,7 +110,7 @@ $ make docs
 
    Afterwards `pre-commit` will run whenever you commit.
 
-   [pre-commit](https://pre-commit.com) is a framework for managing and maintaining multi-language pre-commit hooks to ensure code-style and code formatting is consistent.
+   `pre-commit` is a framework for managing and maintaining multi-language pre-commit hooks to ensure code-style and code formatting is consistent.
 
    Now you have an environment called `intake-esm-dev` that you can work in.
    You’ll need to make sure to activate that environment next time you want

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ $ make docs
    ```
 
    If you need some help with Git, follow this quick start
-   guide: https://git.wiki.kernel.org/index.php/QuickStart
+   guide: https://docs.github.com/en/get-started/getting-started-with-git
 
 3. Install dependencies into a new conda environment::
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,10 +80,10 @@ $ make docs
    $ git remote add upstream git@github.com:intake/intake-esm.git
    ```
 
-   now, to fix a bug or add feature create your own branch off "master":
+   now, to fix a bug or add feature create your own branch off "main":
 
    ```bash
-   $ git checkout -b your-bugfix-feature-branch-name master
+   $ git checkout -b your-bugfix-feature-branch-name main
    ```
 
    If you need some help with Git, follow this quick start
@@ -142,5 +142,5 @@ $ make docs
    compare: your-branch-name
 
    base-fork: intake/intake-esm
-   base: master # if it's a bugfix or feature
+   base: main # if it's a bugfix or feature
    ```


### PR DESCRIPTION
## Change Summary

Whilst skim reading the contributing guidelines to put in the PR #673 I noticed it referred to the `master` branch but the default branch is named `main` so I guess it was renamed but that page has not been updated accordingly. There are also some links which I have updated:
* one which was not formatted properly to form a hyperlink, and also duplicated in terms of stating the URL, so I fixed it and removed the duplicate;
* [one which now leads to a page](https://git.wiki.kernel.org/index.php/QuickStart) which is marked in capitals at the top as a warning 'OBSOLETE CONTENT This wiki has been archived and the content is no longer updated. Please visit [git-scm.com/doc](https://git-scm.com/doc) for up-to-date documentation.' so I thought I should also update that to an up-to-date equivalent.


## Related issue number

Trivial docs page set of minor updates hence I have not raised an Issue first.

## Checklist

- [n/a] Unit tests for the changes exist
- [n/a] Tests pass on CI
- [n/a] Documentation reflects the changes where applicable
