### PR TITLE
Fix how storage_options is passed to get_mapper.

### DIFF
--- a/intake_esm/cat.py
+++ b/intake_esm/cat.py
@@ -178,7 +178,8 @@ class ESMCatalogModel(pydantic.BaseModel):
             directory = os.getcwd()
 
         # Configure the fsspec mapper and associated filenames
-        mapper = fsspec.get_mapper(f'{directory}', storage_options=storage_options)
+        storage_options = storage_options if storage_options is not None else {}
+        mapper = fsspec.get_mapper(f'{directory}', **storage_options)
         fs = mapper.fs
         csv_file_name = fs.unstrip_protocol(f'{mapper.root}/{name}.csv')
         json_file_name = fs.unstrip_protocol(f'{mapper.root}/{name}.json')


### PR DESCRIPTION
## Change Summary

We identified a bug in the ESMCatalogModel.save method where storage_options were not being handled properly. The code now follows the same procedure used in the load method. if storage_options is None is transformed to an empty dict and double star expansion is used to expand it when passed to fsspec.get_mapper. The old way this storage_options where carried out to Aiobotocore.session is s3fs and makig it crash with this error:

```
E           TypeError: AioSession.__init__() got an unexpected keyword argument 'storage_options'
```
This fixed the issue.