### PR TITLE
Fix #684 Merge results from main and derived catalogs

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -421,7 +421,7 @@ class esm_datastore(Catalog):
         if derivedcat_results:
             # Merge results from the main and the derived catalogs
             esmcat_results = pd.concat([esmcat_results, *derivedcat_results])
-            esmcat_results = (esmcat_results[~esmcat_results.astype(str).duplicated()])
+            esmcat_results = esmcat_results[~esmcat_results.astype(str).duplicated()]
 
         cat = self.__class__({'esmcat': self.esmcat.dict(), 'df': esmcat_results})
         cat.esmcat.catalog_file = None  # Don't save the catalog file

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -420,11 +420,8 @@ class esm_datastore(Catalog):
 
         if derivedcat_results:
             # Merge results from the main and the derived catalogs
-            esmcat_results = (
-                pd.concat([esmcat_results, *derivedcat_results])
-                .drop_duplicates()
-                .reset_index(drop=True)
-            )
+            esmcat_results = pd.concat([esmcat_results, *derivedcat_results])
+            esmcat_results = (esmcat_results[~esmcat_results.astype(str).duplicated()])
 
         cat = self.__class__({'esmcat': self.esmcat.dict(), 'df': esmcat_results})
         cat.esmcat.catalog_file = None  # Don't save the catalog file


### PR DESCRIPTION
## Change Summary

`drop_duplicates` does not work on dataframe that contains lists. This causes issue #684.

Will close #684 


## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
