### PR TITLE
Pin xr !=2024.10 in requirements.txt to match ci/environment.yml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ intake>=2.0.0
 netCDF4>=1.5.5
 pandas>=2.1.0
 requests>=2.24.0
-xarray>=2022.06
+xarray>=2022.06, !=2024.10
 zarr>=2.12
 pydantic>=2.0


### PR DESCRIPTION


## Change Summary

xarray 2024.10 had a lot of changes to datatree - this breaks a number of tests. PR #683 pinned the xarray requirements in the CI to avoid this issue. 

I just forgot to update the xarray dependency to`xarray>=2022.06, !=2024.10` in `requirements.txt` to match CI in that PR.

Pending fix - I'd like to relax this before doing a new release (see #688)
 
