### PR TITLE
feat: Support being able to use in-memory ESMCatalogModel instances

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -31,7 +31,8 @@ class esm_datastore(Catalog):
 
     Parameters
     ----------
-    obj : str, dict
+    obj : str, dict, ESMCatalogModel
+        The ESM Catalog to use, or a path to a JSON file containing the catalog.
         If string, this must be a path or URL to an ESM catalog JSON file.
         If dict, this must be a dict representation of an ESM catalog.
         This dict must have two keys: 'esmcat' and 'df'. The 'esmcat' key must be a
@@ -76,7 +77,7 @@ class esm_datastore(Catalog):
 
     def __init__(
         self,
-        obj: pydantic.FilePath | pydantic.AnyUrl | dict[str, typing.Any],
+        obj: pydantic.FilePath | pydantic.AnyUrl | dict[str, typing.Any] | ESMCatalogModel,
         *,
         progressbar: bool = True,
         sep: str = '.',
@@ -101,7 +102,9 @@ class esm_datastore(Catalog):
         self.read_csv_kwargs = read_csv_kwargs
         self.progressbar = progressbar
         self.sep = sep
-        if isinstance(obj, dict):
+        if isinstance(obj, ESMCatalogModel):
+            self.esmcat = obj
+        elif isinstance(obj, dict):
             self.esmcat = ESMCatalogModel.from_dict(obj)
         else:
             self.esmcat = ESMCatalogModel.load(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,6 +63,7 @@ def func_multivar(ds):
         (multi_variable_cat, '*', {'converters': {'variable': ast.literal_eval}}, None),
         (multi_variable_cat, '*', None, ['variable']),
         ({'esmcat': sample_esmcat_data, 'df': sample_df}, '.', None, None),
+        (intake_esm.cat.ESMCatalogModel.load(cdf_cat_sample_cmip6), '.', None, None),
     ],
 )
 def test_catalog_init(capsys, obj, sep, read_csv_kwargs, columns_with_iterables):


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

Support initialising the catalog using an in-memory instance of the data model. This avoids the need to serialise/deserialise if a temporary catalog is needed.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- [x] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
