### PR TITLE
Remove setuptools runtime requirements

### DIFF
--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -20,8 +20,8 @@ dependencies:
   - python-graphviz
   - python=3.11
   - s3fs >=2024.12
-  - setuptools >=65.0.0
-  - setuptools_scm >=7.1.0
+  - setuptools >=75.0.0
+  - setuptools_scm >=8.1.0
   - sphinx <6.0
   - sphinx-copybutton
   - sphinx-design

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -30,8 +30,8 @@ dependencies:
   - pytest-xdist
   - regionmask
   - s3fs >=2024.12
-  - setuptools >=65.0.0
-  - setuptools_scm >=7.1.0
+  - setuptools >=75.0.0
+  - setuptools_scm >=8.1.0
   - scipy
   - xarray-datatree
   - xgcm

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -27,8 +27,8 @@ dependencies:
   - pytest-xdist
   - pytest-mock
   - s3fs >=2024.12
-  - setuptools >=65.0.0
-  - setuptools_scm >=7.1.0
+  - setuptools >=75.0.0
+  - setuptools_scm >=8.1.0
   - scipy
   - xarray >=2024.10
   - xarray-datatree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-    requires = ["setuptools>=45", "setuptools_scm>=6.2", "wheel"]
+    requires = ["setuptools>=75.0", "setuptools_scm>=8.1", "wheel"]
 
 [project]
     classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,5 @@ netCDF4>=1.5.5
 pandas>=2.1.0
 pydantic>=2.0
 requests>=2.24.0
-setuptools>=65.0.0
-setuptools_scm>=7.1.0
 xarray>=2024.10
 zarr>=2.12


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

This PR is a hotfix for #707.

I mistakenly added `setuptools` and `setuptools-scm` to the `requirements.txt` thinking that it would address a bug we were experiencing, but it seems as though that was addressed in [this commit](https://github.com/intake/intake-esm/commit/141425be65c25cbb6b78fb1ec0426593d6157948).

Other changes were good to have, though (Python3.13 metadata, synchronizing dependencies; added `setuptools*` to the `conda` environments).

## Checklist

- [ ] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable
