### PR TITLE
Add optional esmvalcore dependency & `to_iris method

### DIFF
--- a/intake_esm/__init__.py
+++ b/intake_esm/__init__.py
@@ -4,6 +4,7 @@
 
 # Import intake first to avoid circular imports during discovery.
 import intake
+import importlib
 
 
 from intake_esm import tutorial
@@ -12,3 +13,53 @@ from intake_esm.derived import DerivedVariableRegistry, default_registry
 from intake_esm.utils import set_options, show_versions
 
 from intake_esm._version import __version__
+
+_optional_imports: dict[str, bool | None] = {'esmvalcore': None}
+
+
+def _to_opt_import_flag(name: str) -> str:
+    """Dynamically create import flags for optional imports."""
+    return f'_{name.upper()}_AVAILABLE'
+
+
+def _from_opt_import_flag(name: str) -> str:
+    """Dynamically retrive the optional import name from its flag."""
+    if name.startswith('_') and name.endswith('_AVAILABLE'):
+        return name[1:-10].lower()
+    raise ValueError(
+        f"Invalid optional import flag '{name}'. Expected format: '_<import_name>_AVAILABLE'."
+    )
+
+
+__all__ = [
+    'esm_datastore',
+    'DerivedVariableRegistry',
+    'default_registry',
+    'set_options',
+    'show_versions',
+    'tutorial',
+] + [_to_opt_import_flag(name) for name in _optional_imports]
+
+
+def __getattr__(attr: str) -> object:
+    """
+    Lazy load optional imports.
+    """
+
+    if attr in (gl := globals()):
+        return gl[attr]
+
+    import_flags = [_to_opt_import_flag(name) for name in _optional_imports]
+
+    if attr in import_flags:
+        import_name = _from_opt_import_flag(attr)
+        if _optional_imports.get(import_name, None) is None:
+            _optional_imports[import_name] = bool(importlib.util.find_spec(import_name))
+            return _optional_imports[import_name]
+        else:
+            return _optional_imports[import_name]
+
+    raise AttributeError(
+        f"Module '{__name__}' has no attribute '{attr}'. "
+        f'Did you mean one of {", ".join(import_flags)}?'
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+import intake_esm
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -13,3 +15,14 @@ def sample_cmip6():
 @pytest.fixture
 def sample_bad_input():
     return os.path.join(here, 'sample-catalogs/bad.json')
+
+
+@pytest.fixture
+def cleanup_init():
+    """
+    This resets the _optional_imports dictionary in intake_esm to it's default
+    state, so we can test lazy loading and whatnot
+    """
+    yield
+
+    intake_esm._optional_imports = {'esmvalcore': None}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,102 @@
+from unittest import mock
+
+import pytest
+
+
+def test__all__(cleanup_init):
+    import intake_esm
+
+    assert intake_esm.__all__ == [
+        'esm_datastore',
+        'DerivedVariableRegistry',
+        'default_registry',
+        'set_options',
+        'show_versions',
+        'tutorial',
+        '_ESMVALCORE_AVAILABLE',
+    ]
+
+
+def test__to_optional_import_flag(cleanup_init):
+    from intake_esm import _to_opt_import_flag
+
+    assert _to_opt_import_flag('esmvalcore') == '_ESMVALCORE_AVAILABLE'
+    # This looks stupid but we need to be careful re. underscores
+    assert _to_opt_import_flag('intake_esm') == '_INTAKE_ESM_AVAILABLE'
+
+
+def test__from_optional_import_flag(cleanup_init):
+    from intake_esm import _from_opt_import_flag
+
+    assert _from_opt_import_flag('_ESMVALCORE_AVAILABLE') == 'esmvalcore'
+    # This looks stupid but we need to be careful re. underscores
+    assert _from_opt_import_flag('_INTAKE_ESM_AVAILABLE') == 'intake_esm'
+
+
+@pytest.mark.parametrize(
+    'str',
+    [
+        '_ESMVALCORE_AVAILABLE',
+        '_INTAKE_ESM_AVAILABLE',
+    ],
+)
+def test__opt_import_flags(cleanup_init, str):
+    from intake_esm import _from_opt_import_flag, _to_opt_import_flag
+
+    assert _to_opt_import_flag(_from_opt_import_flag(str)) == str
+
+
+@pytest.mark.parametrize(
+    'str',
+    [
+        '_INVALID_FLAG',
+        'invalid_flag',
+        'INVALID_FLAG_AVAILABLE',
+    ],
+)
+def test__opt_import_flags_invalid(cleanup_init, str):
+    from intake_esm import _from_opt_import_flag
+
+    with pytest.raises(ValueError):
+        _from_opt_import_flag(str)
+
+
+@pytest.mark.parametrize(
+    'str',
+    [
+        'esmvalcore',
+        'intake_esm',
+    ],
+)
+def test_rev_opt_import_flags(cleanup_init, str):
+    from intake_esm import _from_opt_import_flag, _to_opt_import_flag
+
+    assert _from_opt_import_flag(_to_opt_import_flag(str)) == str
+
+
+def test_getattr_random_attr_fail(cleanup_init):
+    import intake_esm
+
+    with pytest.raises(AttributeError, match="Module 'intake_esm' has no attribute 'random_attr'"):
+        _ = intake_esm.random_attr
+
+
+def test_getattr_optional_import(cleanup_init):
+    import intake_esm
+
+    assert intake_esm._optional_imports == {'esmvalcore': None}
+
+    assert intake_esm._ESMVALCORE_AVAILABLE is False
+    assert intake_esm._optional_imports == {'esmvalcore': False}
+
+
+@mock.patch('importlib.util.find_spec', return_value=True)
+def test_getattr_caching(mock_find_spec, cleanup_init):
+    import intake_esm
+
+    # Simulate the first call to find_spec
+    mock_find_spec.return_value = True
+    assert intake_esm._ESMVALCORE_AVAILABLE is True
+    assert intake_esm._ESMVALCORE_AVAILABLE is True
+
+    mock_find_spec.assert_called_once_with('esmvalcore')


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
## Changes
- Add optional imports following the way polars does it to keep overhead to a minimum.
- Add esmvalcore to list of optional imports.

<!-- Please give a short summary of the changes. -->

## Related issue number

#715 

Closes #715 

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
