### PR TITLE
Improve test performance

### DIFF
--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -6,6 +6,7 @@ import dask
 import pytest
 import xarray
 from dask.delayed import DelayedLeaf
+from typing_extensions import assert_type
 
 from intake_esm.source import (
     _delayed_open_ds,
@@ -178,10 +179,11 @@ def test_request_coord_vars(fpath, dvars, cvars, expected):
         (False, _eager_open_ds),
     ],
 )
-def test_get_open_func(threaded, expected):
+def test_get_open_func(threaded: bool, expected):
     """Test that the correct open function is returned based on the threaded argument."""
     open_func = _get_open_func(threaded)
     if not threaded:
         assert open_func == _eager_open_ds
     else:
-        assert isinstance(open_func, DelayedLeaf)
+        assert_type(open_func, DelayedLeaf)
+        # assert isinstance(open_func, DelayedLeaf)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -6,7 +6,6 @@ import dask
 import pytest
 import xarray
 from dask.delayed import DelayedLeaf
-from typing_extensions import assert_type
 
 from intake_esm.source import (
     _delayed_open_ds,
@@ -92,7 +91,7 @@ def test_open_dataset_kerchunk(kerchunk_file=kerchunk_file):
         urlpath=kerchunk_file,
         varname=None,
         xarray_open_kwargs=xarray_open_kwargs,
-    ).compute()
+    )
     assert isinstance(ds, xarray.Dataset)
 
 
@@ -185,5 +184,4 @@ def test_get_open_func(threaded: bool, expected):
     if not threaded:
         assert open_func == _eager_open_ds
     else:
-        assert_type(open_func, DelayedLeaf)
-        # assert isinstance(open_func, DelayedLeaf)
+        assert isinstance(open_func, DelayedLeaf)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -178,7 +178,7 @@ def test_request_coord_vars(fpath, dvars, cvars, expected):
         (False, _eager_open_ds),
     ],
 )
-def test_get_open_func(threaded: bool, expected):
+def test_get_open_func(threaded, expected):
     """Test that the correct open function is returned based on the threaded argument."""
     open_func = _get_open_func(threaded)
     if not threaded:


### PR DESCRIPTION
## Change Summary

Removed a `.compute()` call from `test_open_dataset_kerchunk`. It's been bugging me for a couple of days that the tests seemed to be running excessively slowly.

The kerchunk file that was being computed is approximate 2GB in size & we shouldn't need to have a `.compute()` call to assert that it is a dataset (AFAIK).

This reduces test suite execution time from:
-  ~220s to ~120s on my machine
-  ~130s to 105s on CI


## Checklist

- [x] Unit tests for the changes exist N/A
- [x] Tests pass on CI 
- [x] Documentation reflects the changes where applicable N/A 

<!--
Please add any other relevant info below:
-->
