### PR TITLE
Add interactive view of catalog

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - h5netcdf >=0.8.1
   - intake >=2.0
   - ipython
+  - itables
   - matplotlib
   - netcdf4 >=1.5.5,!=1.6.1
   - pandas >=2.1.0

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -17,6 +17,7 @@ try:
     _DATATREE_AVAILABLE = True
 except ImportError:
     _DATATREE_AVAILABLE = False
+import itables
 import pandas as pd
 import pydantic
 from fastprogress.fastprogress import progress_bar
@@ -211,6 +212,18 @@ class esm_datastore(Catalog):
         Return pandas :py:class:`~pandas.DataFrame`.
         """
         return self.esmcat.df
+
+    @property
+    def interactive(self) -> None:
+        """
+        Use itables to display the catalog in an interactive table. Use polars
+        for performance ideally. Fall back to pandas if not.
+        """
+        try:
+            df = self.esmcat._frames.polars  # type:ignore[union-attr]
+        except AttributeError:
+            df = self.esmcat.df
+        return itables.show(df)
 
     def __len__(self) -> int:
         return len(self.keys())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ dask[complete]>=2024.12
 fastprogress>=1.0.0
 fsspec>=2024.12
 intake>=2.0.0
+itables
 netCDF4>=1.5.5
 pandas>=2.1.0
 polars>=1.24.0


### PR DESCRIPTION
## Change Summary

- Add [itables dependency](https://github.com/mwouts/itables) as an interactive catalog viewer.
- Displays polars df if possible, falling back to pandas if necessary. Not sure how much performance is going to be bottlenecked by JavaScript anyway.

## Related issue number

N/A

## Checklist

- [ ] Unit tests for the changes exist || Not sure what it really even means to test this yet
- [ ] Tests pass on CI 
- [ ] Documentation reflects the changes where applicable 


<img width="908" alt="Screenshot 2025-06-04 at 7 40 38 am" src="https://github.com/user-attachments/assets/7ba0aea4-6a23-494c-b8e3-74d4e4c6c092" />

