### PR TITLE
Replace Pydantic .dict() with .model_dump()

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -492,7 +492,7 @@ class esm_datastore(Catalog):
             esmcat_results = pd.concat([esmcat_results, *derivedcat_results])
             esmcat_results = esmcat_results[~esmcat_results.astype(str).duplicated()]
 
-        cat = self.__class__({'esmcat': self.esmcat.dict(), 'df': esmcat_results})
+        cat = self.__class__({'esmcat': self.esmcat.model_dump(), 'df': esmcat_results})
         cat.esmcat.catalog_file = None  # Don't save the catalog file
         if self.esmcat.has_multiple_variable_assets:
             requested_variables = list(set(variables or []).union(dependents))


### PR DESCRIPTION
## Change Summary

The Pydantic `dict()` method has been renamed `model_dump()` (the `dict()` alias is deprecated in Pydantic V2 and will be removed in Pydantic V3). The `dict()` and `model_dump()` methods work identically in Pydantic V2, so this switch shouldn't affect anything.

## Related issue number

Closes #745

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable