### PR TITLE
Fix fastprogress ipython issue - explicitly install ipython in `pypi.yml` verify built dist step.

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -66,6 +66,8 @@ jobs:
         if: github.event_name == 'push'
         run: |
           python -m pip install --upgrade pip
+          python -m pip install ipython
+          # Explicitly install ipython: see https://github.com/AnswerDotAI/fastprogress/issues/117
           python -m pip install dist/intake_esm*.whl
           python -c "import intake_esm; print(intake_esm.__version__)"
 


### PR DESCRIPTION
## Change Summary

It looks like Ipython became an optional dependency for fastprogress in a recent version - this just explicitly installs it so CI runs.

## Related issue number

see https://github.com/AnswerDotAI/fastprogress/issues/117


## Checklist

- [ ] Unit tests for the changes exist N/A
- [ ] Tests pass on CI N/A
- [ ] Documentation reflects the changes where applicable N/A

<!--
Please add any other relevant info below:
-->
