### PR TITLE
Restrict `fastprogress` version to fix downstream `ModuleNotFoundError` errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ concurrency:
 jobs:
   build:
     name: python-${{ matrix.python-version }}
-    if: github.repository == 'intake/intake-esm'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -62,7 +61,6 @@ jobs:
 
   upstream-dev:
     name: upstream-dev
-    if: github.repository == 'intake/intake-esm'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
-    if: github.repository == 'intake/intake-esm'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -66,8 +66,6 @@ jobs:
         if: github.event_name == 'push'
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ipython
-          # Explicitly install ipython: see https://github.com/AnswerDotAI/fastprogress/issues/117
           python -m pip install dist/intake_esm*.whl
           python -c "import intake_esm; print(intake_esm.__version__)"
 

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - cftime
   - codecov
   - dask >=2024.12
-  - fastprogress >=1.0.0
+  - fastprogress>=1.0.0,<1.1.0
   - flaky >= 3.8.0
   - gcsfs >=2024.12
   - h5netcdf >=0.8.1

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - cftime
   - codecov
   - dask >=2024.12
-  - fastprogress >=1.0.0
+  - fastprogress>=1.0.0,<1.1.0
   - flaky >=3.8.0
   - fsspec >=2024.12
   - gcsfs >=2024.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask[complete]>=2024.12
-fastprogress>=1.0.0
+fastprogress>=1.0.0,<1.1.0
 fsspec>=2024.12
 intake>=2.0.0
 itables


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

I and others on my team started noticing failures in [NOAA-GFDL/fre-cli](https://github.com/noaa-gfdl/fre-cli) and [NOAA-GFDL/catalogbuilder](https://github.com/noaa-gfdl/catalogbuilder). The error messages had nothing to do directly with our changes, see [this PR](https://github.com/NOAA-GFDL/fre-cli/pull/693#issuecomment-3746167877) comment as an example.

I chased this down to both https://github.com/AnswerDotAI/fastprogress/issues/117, and then also the fix in https://github.com/intake/intake-esm/pull/770. After examining the fix and the situation with `fastprogress`, i decided to explore this quick alternate solution. 

[From what I can tell](https://github.com/ilaflott/intake-esm/actions/runs/20972319878), it [works](https://github.com/ilaflott/intake-esm/actions/runs/20972321050). I hope it works in this repository's CI as well as it appeared to work on my fork.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

https://github.com/AnswerDotAI/fastprogress/issues/117

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
